### PR TITLE
Support for using VarPatternSyntax as discard

### DIFF
--- a/ExhaustiveMatching.Analyzer.Tests/CodeContext.cs
+++ b/ExhaustiveMatching.Analyzer.Tests/CodeContext.cs
@@ -40,6 +40,7 @@ enum CoinFlip {{ Heads, Tails }}";
 using System.ComponentModel; // InvalidEnumArgumentException
 using ExhaustiveMatching;
 using TestNamespace;
+using Nisse;
 
 class TestClass
 {{
@@ -60,7 +61,15 @@ namespace TestNamespace
     public abstract class Triangle : Shape {{ }} // abstract to show abstract leaf types are checked
     public class EquilateralTriangle : Triangle {{ }}
     public class IsoscelesTriangle : Triangle {{ }}
-}}";
+}}
+
+namespace Nisse {{
+    public sealed class ValueOutOfRangeException: Exception {{
+        public ValueOutOfRangeException(string what, object? value) {{
+        }}
+    }}
+}}
+";
             return string.Format(context, args, body);
         }
     }

--- a/ExhaustiveMatching.Analyzer.Tests/CodeContext.cs
+++ b/ExhaustiveMatching.Analyzer.Tests/CodeContext.cs
@@ -65,6 +65,8 @@ namespace TestNamespace
 
 namespace Nisse {{
     public sealed class ValueOutOfRangeException: Exception {{
+        public bool DoNotValidate;
+
         public ValueOutOfRangeException(string what, object? value) {{
         }}
     }}

--- a/ExhaustiveMatching.Analyzer.Tests/ExhaustiveMatching.Analyzer.Tests.csproj
+++ b/ExhaustiveMatching.Analyzer.Tests/ExhaustiveMatching.Analyzer.Tests.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.3.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/ExhaustiveMatching.Analyzer.Tests/SwitchExpressionAnalyzerTests.cs
+++ b/ExhaustiveMatching.Analyzer.Tests/SwitchExpressionAnalyzerTests.cs
@@ -480,6 +480,26 @@ namespace TestNamespace
             await VerifyCSharpDiagnosticsAsync(source, expectedTails);
         }
 
+        [Fact]
+        public async Task MatchOnTypeShouldNotRequireToDeclareAVariable()
+        {
+            const string args = "Shape shape";
+            const string test = @"
+        var result = shape ◊1⟦switch⟧
+        {
+            Square square => ""Square: "" + square,
+            Circle => ""Circle"",
+            _ => throw ExhaustiveMatch.Failed(shape)
+        };";
+
+            var source = CodeContext.Shapes(args, test);
+            var expectedTriangle = DiagnosticResult
+                .Error("EM0003", "Subtype not handled by switch: TestNamespace.Triangle")
+                .AddLocation(source, 1);
+
+            await VerifyCSharpDiagnosticsAsync(source, expectedTriangle);
+        }
+
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
             return new ExhaustiveMatchAnalyzer();

--- a/ExhaustiveMatching.Analyzer.Tests/SwitchExpressionAnalyzerTests.cs
+++ b/ExhaustiveMatching.Analyzer.Tests/SwitchExpressionAnalyzerTests.cs
@@ -540,6 +540,23 @@ namespace TestNamespace
             await VerifyCSharpDiagnosticsAsync(source, expectedTriangle);
         }
 
+        [Fact]
+        public async Task SwitchOnStringsShouldNotReportAnything()
+        {
+            const string args = "string str";
+            const string test = @"
+        var result = str switch
+        {
+            ""1"" => 1,
+            ""2"" => 2,
+            var s => throw new ValueOutOfRangeException(""String"", str) { DoNotValidate = true }
+        };";
+
+            var source = CodeContext.Shapes(args, test);
+
+            await VerifyCSharpDiagnosticsAsync(source);
+        }
+
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
             return new ExhaustiveMatchAnalyzer();

--- a/ExhaustiveMatching.Analyzer.Tests/SwitchExpressionAnalyzerTests.cs
+++ b/ExhaustiveMatching.Analyzer.Tests/SwitchExpressionAnalyzerTests.cs
@@ -126,8 +126,11 @@ namespace ExhaustiveMatching.Analyzer.Tests
             var compileError = DiagnosticResult
                                .Error("CS0029", "Cannot implicitly convert type 'int' to 'TestNamespace.Shape'")
                                .AddLocation(source, 2);
+            var expected2 = DiagnosticResult
+                            .Error("EM0101", "Case pattern not supported in exhaustive switch: 12")
+                            .AddLocation(source, 2);
 
-            await VerifyCSharpDiagnosticsAsync(source, expected1, compileError);
+            await VerifyCSharpDiagnosticsAsync(source, expected1, compileError, expected2);
         }
 
         [Fact]
@@ -144,13 +147,19 @@ namespace ExhaustiveMatching.Analyzer.Tests
         };";
 
             var source = CodeContext.Shapes(args, test);
+            var expected1 = DiagnosticResult
+                            .Error("EM0102", "Exhaustive switch must be on enum or closed type, was on: System.Object")
+                            .AddLocation(source, 1);
 
             // Still reports these errors
-            var expected = DiagnosticResult
+            var expected2 = DiagnosticResult
                             .Error("EM0100", "When guard is not supported in an exhaustive switch")
                             .AddLocation(source, 2);
+            var expected3 = DiagnosticResult
+                            .Error("EM0101", "Case pattern not supported in exhaustive switch: 12")
+                            .AddLocation(source, 3);
 
-            await VerifyCSharpDiagnosticsAsync(source, expected);
+            await VerifyCSharpDiagnosticsAsync(source, expected1, expected2, expected3);
         }
 
         [Fact]
@@ -344,12 +353,14 @@ namespace TestNamespace
         };";
 
             var source = CodeContext.Basic(args, test);
-
+            var expected = DiagnosticResult
+                           .Error("EM0102", "Exhaustive switch must be on enum or closed type, was on: System.HashCode")
+                           .AddLocation(source, 1);
             var compileError = DiagnosticResult
                                .Error("CS8510", "The pattern is unreachable. It has already been handled by a previous arm of the switch expression or it is impossible to match.")
                                .AddLocation(source, 2);
 
-            await VerifyCSharpDiagnosticsAsync(source, compileError);
+            await VerifyCSharpDiagnosticsAsync(source, expected, compileError);
         }
 
         [Fact]
@@ -364,8 +375,11 @@ namespace TestNamespace
         };";
 
             var source = CodeContext.Basic(args, test);
+            var expected = DiagnosticResult
+                           .Error("EM0102", "Exhaustive switch must be on enum or closed type, was on: System.Nullable")
+                           .AddLocation(source, 1);
 
-            await VerifyCSharpDiagnosticsAsync(source);
+            await VerifyCSharpDiagnosticsAsync(source, expected);
         }
 
         [Fact]
@@ -380,13 +394,16 @@ namespace TestNamespace
         };";
 
             var source = CodeContext.Shapes(args, test);
-
-            var expected = DiagnosticResult
+            // TODO type name is bad
+            var expected1 = DiagnosticResult
+                            .Error("EM0102", "Exhaustive switch must be on enum or closed type, was on: System.ValueTuple")
+                            .AddLocation(source, 1);
+            var expected2 = DiagnosticResult
                             .Error("EM0101",
                                 "Case pattern not supported in exhaustive switch: (Square square1, Square square2)")
                             .AddLocation(source, 2);
 
-            await VerifyCSharpDiagnosticsAsync(source, expected);
+            await VerifyCSharpDiagnosticsAsync(source, expected1, expected2);
         }
 
         [Fact]
@@ -402,13 +419,16 @@ namespace TestNamespace
         };";
 
             var source = CodeContext.Shapes(args, test);
-
-            var expected = DiagnosticResult
+            // TODO type name is bad
+            var expected1 = DiagnosticResult
+                            .Error("EM0102", "Exhaustive switch must be on enum or closed type, was on: System.Nullable")
+                            .AddLocation(source, 1);
+            var expected2 = DiagnosticResult
                             .Error("EM0101",
                                 "Case pattern not supported in exhaustive switch: (Square square1, Square square2)")
                             .AddLocation(source, 2);
 
-            await VerifyCSharpDiagnosticsAsync(source, expected);
+            await VerifyCSharpDiagnosticsAsync(source, expected1, expected2);
         }
 
         [Fact]
@@ -518,23 +538,6 @@ namespace TestNamespace
                 .AddLocation(source, 1);
 
             await VerifyCSharpDiagnosticsAsync(source, expectedTriangle);
-        }
-
-        [Fact]
-        public async Task SwitchOnStringsShouldNotReportAnything()
-        {
-            const string args = "string str";
-            const string test = @"
-        var result = str switch
-        {
-            ""1"" => 1,
-            ""2"" => 2,
-            var s => throw new ValueOutOfRangeException(""String"", str)
-        };";
-
-            var source = CodeContext.Shapes(args, test);
-
-            await VerifyCSharpDiagnosticsAsync(source);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/ExhaustiveMatching.Analyzer.Tests/SwitchExpressionAnalyzerTests.cs
+++ b/ExhaustiveMatching.Analyzer.Tests/SwitchExpressionAnalyzerTests.cs
@@ -520,6 +520,26 @@ namespace TestNamespace
             await VerifyCSharpDiagnosticsAsync(source, expectedTriangle);
         }
 
+        [Fact]
+        public async Task TestValueOutOfRangeExceptionIsAlsoSupported()
+        {
+            const string args = "Shape shape";
+            const string test = @"
+        var result = shape ◊1⟦switch⟧
+        {
+            Square square => ""Square: "" + square,
+            Circle => ""Circle"",
+            var s => throw new ValueOutOfRangeException(""Shape"", shape)
+        };";
+
+            var source = CodeContext.Shapes(args, test);
+            var expectedTriangle = DiagnosticResult
+                .Error("EM0003", "Subtype not handled by switch: TestNamespace.Triangle")
+                .AddLocation(source, 1);
+
+            await VerifyCSharpDiagnosticsAsync(source, expectedTriangle);
+        }
+
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
             return new ExhaustiveMatchAnalyzer();

--- a/ExhaustiveMatching.Analyzer.Tests/SwitchExpressionAnalyzerTests.cs
+++ b/ExhaustiveMatching.Analyzer.Tests/SwitchExpressionAnalyzerTests.cs
@@ -126,11 +126,8 @@ namespace ExhaustiveMatching.Analyzer.Tests
             var compileError = DiagnosticResult
                                .Error("CS0029", "Cannot implicitly convert type 'int' to 'TestNamespace.Shape'")
                                .AddLocation(source, 2);
-            var expected2 = DiagnosticResult
-                            .Error("EM0101", "Case pattern not supported in exhaustive switch: 12")
-                            .AddLocation(source, 2);
 
-            await VerifyCSharpDiagnosticsAsync(source, expected1, compileError, expected2);
+            await VerifyCSharpDiagnosticsAsync(source, expected1, compileError);
         }
 
         [Fact]
@@ -147,19 +144,13 @@ namespace ExhaustiveMatching.Analyzer.Tests
         };";
 
             var source = CodeContext.Shapes(args, test);
-            var expected1 = DiagnosticResult
-                            .Error("EM0102", "Exhaustive switch must be on enum or closed type, was on: System.Object")
-                            .AddLocation(source, 1);
 
             // Still reports these errors
-            var expected2 = DiagnosticResult
+            var expected = DiagnosticResult
                             .Error("EM0100", "When guard is not supported in an exhaustive switch")
                             .AddLocation(source, 2);
-            var expected3 = DiagnosticResult
-                            .Error("EM0101", "Case pattern not supported in exhaustive switch: 12")
-                            .AddLocation(source, 3);
 
-            await VerifyCSharpDiagnosticsAsync(source, expected1, expected2, expected3);
+            await VerifyCSharpDiagnosticsAsync(source, expected);
         }
 
         [Fact]
@@ -353,14 +344,12 @@ namespace TestNamespace
         };";
 
             var source = CodeContext.Basic(args, test);
-            var expected = DiagnosticResult
-                           .Error("EM0102", "Exhaustive switch must be on enum or closed type, was on: System.HashCode")
-                           .AddLocation(source, 1);
+
             var compileError = DiagnosticResult
                                .Error("CS8510", "The pattern is unreachable. It has already been handled by a previous arm of the switch expression or it is impossible to match.")
                                .AddLocation(source, 2);
 
-            await VerifyCSharpDiagnosticsAsync(source, expected, compileError);
+            await VerifyCSharpDiagnosticsAsync(source, compileError);
         }
 
         [Fact]
@@ -375,11 +364,8 @@ namespace TestNamespace
         };";
 
             var source = CodeContext.Basic(args, test);
-            var expected = DiagnosticResult
-                           .Error("EM0102", "Exhaustive switch must be on enum or closed type, was on: System.Nullable")
-                           .AddLocation(source, 1);
 
-            await VerifyCSharpDiagnosticsAsync(source, expected);
+            await VerifyCSharpDiagnosticsAsync(source);
         }
 
         [Fact]
@@ -394,16 +380,13 @@ namespace TestNamespace
         };";
 
             var source = CodeContext.Shapes(args, test);
-            // TODO type name is bad
-            var expected1 = DiagnosticResult
-                            .Error("EM0102", "Exhaustive switch must be on enum or closed type, was on: System.ValueTuple")
-                            .AddLocation(source, 1);
-            var expected2 = DiagnosticResult
+
+            var expected = DiagnosticResult
                             .Error("EM0101",
                                 "Case pattern not supported in exhaustive switch: (Square square1, Square square2)")
                             .AddLocation(source, 2);
 
-            await VerifyCSharpDiagnosticsAsync(source, expected1, expected2);
+            await VerifyCSharpDiagnosticsAsync(source, expected);
         }
 
         [Fact]
@@ -419,16 +402,13 @@ namespace TestNamespace
         };";
 
             var source = CodeContext.Shapes(args, test);
-            // TODO type name is bad
-            var expected1 = DiagnosticResult
-                            .Error("EM0102", "Exhaustive switch must be on enum or closed type, was on: System.Nullable")
-                            .AddLocation(source, 1);
-            var expected2 = DiagnosticResult
+
+            var expected = DiagnosticResult
                             .Error("EM0101",
                                 "Case pattern not supported in exhaustive switch: (Square square1, Square square2)")
                             .AddLocation(source, 2);
 
-            await VerifyCSharpDiagnosticsAsync(source, expected1, expected2);
+            await VerifyCSharpDiagnosticsAsync(source, expected);
         }
 
         [Fact]
@@ -538,6 +518,23 @@ namespace TestNamespace
                 .AddLocation(source, 1);
 
             await VerifyCSharpDiagnosticsAsync(source, expectedTriangle);
+        }
+
+        [Fact]
+        public async Task SwitchOnStringsShouldNotReportAnything()
+        {
+            const string args = "string str";
+            const string test = @"
+        var result = str switch
+        {
+            ""1"" => 1,
+            ""2"" => 2,
+            var s => throw new ValueOutOfRangeException(""String"", str)
+        };";
+
+            var source = CodeContext.Shapes(args, test);
+
+            await VerifyCSharpDiagnosticsAsync(source);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/ExhaustiveMatching.Analyzer.Tests/SwitchExpressionAnalyzerTests.cs
+++ b/ExhaustiveMatching.Analyzer.Tests/SwitchExpressionAnalyzerTests.cs
@@ -357,7 +357,7 @@ namespace TestNamespace
                            .Error("EM0102", "Exhaustive switch must be on enum or closed type, was on: System.HashCode")
                            .AddLocation(source, 1);
             var compileError = DiagnosticResult
-                               .Error("CS8510", "The pattern has already been handled by a previous arm of the switch expression.")
+                               .Error("CS8510", "The pattern is unreachable. It has already been handled by a previous arm of the switch expression or it is impossible to match.")
                                .AddLocation(source, 2);
 
             await VerifyCSharpDiagnosticsAsync(source, expected, compileError);
@@ -396,7 +396,7 @@ namespace TestNamespace
             var source = CodeContext.Shapes(args, test);
             // TODO type name is bad
             var expected1 = DiagnosticResult
-                            .Error("EM0102", "Exhaustive switch must be on enum or closed type, was on: System.")
+                            .Error("EM0102", "Exhaustive switch must be on enum or closed type, was on: System.ValueTuple")
                             .AddLocation(source, 1);
             var expected2 = DiagnosticResult
                             .Error("EM0101",
@@ -456,7 +456,7 @@ namespace TestNamespace
 }";
 
             var compileError = DiagnosticResult
-                .Error("CS8510", "The pattern has already been handled by a previous arm of the switch expression.")
+                .Error("CS8510", "The pattern is unreachable. It has already been handled by a previous arm of the switch expression or it is impossible to match.")
                 .AddLocation(source, 1);
 
             await VerifyCSharpDiagnosticsAsync(source, compileError);

--- a/ExhaustiveMatching.Analyzer.Tests/SwitchExpressionAnalyzerTests.cs
+++ b/ExhaustiveMatching.Analyzer.Tests/SwitchExpressionAnalyzerTests.cs
@@ -500,6 +500,26 @@ namespace TestNamespace
             await VerifyCSharpDiagnosticsAsync(source, expectedTriangle);
         }
 
+        [Fact]
+        public async Task MatchOnTypeShouldWorkWithVarPatternAsDiscardPattern()
+        {
+            const string args = "Shape shape";
+            const string test = @"
+        var result = shape ◊1⟦switch⟧
+        {
+            Square square => ""Square: "" + square,
+            Circle => ""Circle"",
+            var s => throw ExhaustiveMatch.Failed(s)
+        };";
+
+            var source = CodeContext.Shapes(args, test);
+            var expectedTriangle = DiagnosticResult
+                .Error("EM0003", "Subtype not handled by switch: TestNamespace.Triangle")
+                .AddLocation(source, 1);
+
+            await VerifyCSharpDiagnosticsAsync(source, expectedTriangle);
+        }
+
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
             return new ExhaustiveMatchAnalyzer();

--- a/ExhaustiveMatching.Analyzer.Tests/SwitchStatementAnalyzerTests.cs
+++ b/ExhaustiveMatching.Analyzer.Tests/SwitchStatementAnalyzerTests.cs
@@ -545,6 +545,32 @@ namespace TestNamespace
             await VerifyCSharpDiagnosticsAsync(source, expected1, expected2);
         }
 
+        [Fact]
+        public async Task DefaultCaseWithBracesShouldBeSupportedToo()
+        {
+            const string args = "Shape shape";
+            const string test = @"
+        ◊1⟦switch⟧ (shape)
+        {
+            case Square square:
+                Console.WriteLine(""Square: "" + square);
+                break;
+            case Circle circle:
+                Console.WriteLine(""Circle: "" + circle);
+                break;
+            default: {
+                throw ExhaustiveMatch.Failed(shape);
+            }
+        }";
+
+            var source = CodeContext.Shapes(args, test);
+            var expectedTriangle = DiagnosticResult
+                .Error("EM0003", "Subtype not handled by switch: TestNamespace.Triangle")
+                .AddLocation(source, 1);
+
+            await VerifyCSharpDiagnosticsAsync(source, expectedTriangle);
+        }
+
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
             return new ExhaustiveMatchAnalyzer();

--- a/ExhaustiveMatching.Analyzer.Tests/SwitchStatementAnalyzerTests.cs
+++ b/ExhaustiveMatching.Analyzer.Tests/SwitchStatementAnalyzerTests.cs
@@ -507,7 +507,7 @@ namespace TestNamespace
             var source = CodeContext.Shapes(args, test);
             // TODO type name is bad
             var expected1 = DiagnosticResult
-                            .Error("EM0102", "Exhaustive switch must be on enum or closed type, was on: System.")
+                            .Error("EM0102", "Exhaustive switch must be on enum or closed type, was on: System.ValueTuple")
                             .AddLocation(source, 1);
             var expected2 = DiagnosticResult
                             .Error("EM0101", "Case pattern not supported in exhaustive switch: (Square square1, Square square2)")

--- a/ExhaustiveMatching.Analyzer.Tests/SwitchStatementAnalyzerTests.cs
+++ b/ExhaustiveMatching.Analyzer.Tests/SwitchStatementAnalyzerTests.cs
@@ -219,16 +219,19 @@ namespace ExhaustiveMatching.Analyzer.Tests
         }";
 
             var source = CodeContext.Shapes(args, test);
+            var expected1 = DiagnosticResult
+                            .Error("EM0102", "Exhaustive switch must be on enum or closed type, was on: System.Object")
+                            .AddLocation(source, 1);
 
             // Still reports these errors
-            var expected1 = DiagnosticResult
+            var expected2 = DiagnosticResult
                             .Error("EM0100", "When guard is not supported in an exhaustive switch")
                             .AddLocation(source, 2);
-            var expected2 = DiagnosticResult
+            var expected3 = DiagnosticResult
                             .Error("EM0101", "Case pattern not supported in exhaustive switch: 12")
                             .AddLocation(source, 3);
 
-            await VerifyCSharpDiagnosticsAsync(source, expected1, expected2);
+            await VerifyCSharpDiagnosticsAsync(source, expected1, expected2, expected3);
         }
 
         [Fact]
@@ -455,8 +458,10 @@ namespace TestNamespace
         }";
 
             var source = CodeContext.Basic(args, test);
+            var expected = DiagnosticResult.Error("EM0102", "Exhaustive switch must be on enum or closed type, was on: System.HashCode")
+                                                 .AddLocation(source, 1);
 
-            await VerifyCSharpDiagnosticsAsync(source);
+            await VerifyCSharpDiagnosticsAsync(source, expected);
         }
 
         [Fact]
@@ -477,8 +482,11 @@ namespace TestNamespace
         }";
 
             var source = CodeContext.Basic(args, test);
+            var expected = DiagnosticResult
+                           .Error("EM0102", "Exhaustive switch must be on enum or closed type, was on: System.Nullable")
+                           .AddLocation(source, 1);
 
-            await VerifyCSharpDiagnosticsAsync(source);
+            await VerifyCSharpDiagnosticsAsync(source, expected);
         }
 
         [Fact]
@@ -497,12 +505,15 @@ namespace TestNamespace
         }";
 
             var source = CodeContext.Shapes(args, test);
-
-            var expected = DiagnosticResult
+            // TODO type name is bad
+            var expected1 = DiagnosticResult
+                            .Error("EM0102", "Exhaustive switch must be on enum or closed type, was on: System.ValueTuple")
+                            .AddLocation(source, 1);
+            var expected2 = DiagnosticResult
                             .Error("EM0101", "Case pattern not supported in exhaustive switch: (Square square1, Square square2)")
                             .AddLocation(source, 2);
 
-            await VerifyCSharpDiagnosticsAsync(source, expected);
+            await VerifyCSharpDiagnosticsAsync(source, expected1, expected2);
         }
 
         [Fact]
@@ -522,13 +533,16 @@ namespace TestNamespace
         }";
 
             var source = CodeContext.Shapes(args, test);
-
-            var expected = DiagnosticResult
+            // TODO type name is bad
+            var expected1 = DiagnosticResult
+                            .Error("EM0102", "Exhaustive switch must be on enum or closed type, was on: System.Nullable")
+                            .AddLocation(source, 1);
+            var expected2 = DiagnosticResult
                             .Error("EM0101",
                                 "Case pattern not supported in exhaustive switch: (Square square1, Square square2)")
                             .AddLocation(source, 2);
 
-            await VerifyCSharpDiagnosticsAsync(source, expected);
+            await VerifyCSharpDiagnosticsAsync(source, expected1, expected2);
         }
 
         [Fact]

--- a/ExhaustiveMatching.Analyzer.Tests/SwitchStatementAnalyzerTests.cs
+++ b/ExhaustiveMatching.Analyzer.Tests/SwitchStatementAnalyzerTests.cs
@@ -571,6 +571,26 @@ namespace TestNamespace
             await VerifyCSharpDiagnosticsAsync(source, expectedTriangle);
         }
 
+        [Fact]
+        public async Task SwitchWithoutDefaultCaseShouldNotFail()
+        {
+            const string args = "Shape shape";
+            const string test = @"
+        ◊1⟦switch⟧ (shape)
+        {
+            case Square square:
+                Console.WriteLine(""Square: "" + square);
+                break;
+            case Circle circle:
+                Console.WriteLine(""Circle: "" + circle);
+                break;
+        }";
+
+            var source = CodeContext.Shapes(args, test);
+
+            await VerifyCSharpDiagnosticsAsync(source);
+        }
+
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
             return new ExhaustiveMatchAnalyzer();

--- a/ExhaustiveMatching.Analyzer.Tests/SwitchStatementAnalyzerTests.cs
+++ b/ExhaustiveMatching.Analyzer.Tests/SwitchStatementAnalyzerTests.cs
@@ -591,6 +591,31 @@ namespace TestNamespace
             await VerifyCSharpDiagnosticsAsync(source);
         }
 
+        [Fact]
+        public async Task TestValueOutOfRangeExceptionIsAlsoSupported()
+        {
+            const string args = "Shape shape";
+            const string test = @"
+        ◊1⟦switch⟧ (shape)
+        {
+            case Square square:
+                Console.WriteLine(""Square: "" + square);
+                break;
+            case Circle circle:
+                Console.WriteLine(""Circle: "" + circle);
+                break;
+            default:
+                throw new ValueOutOfRangeException(""Shape"", shape);
+        }";
+
+            var source = CodeContext.Shapes(args, test);
+            var expectedTriangle = DiagnosticResult
+                .Error("EM0003", "Subtype not handled by switch: TestNamespace.Triangle")
+                .AddLocation(source, 1);
+
+            await VerifyCSharpDiagnosticsAsync(source, expectedTriangle);
+        }
+
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
             return new ExhaustiveMatchAnalyzer();

--- a/ExhaustiveMatching.Analyzer.Tests/SwitchStatementAnalyzerTests.cs
+++ b/ExhaustiveMatching.Analyzer.Tests/SwitchStatementAnalyzerTests.cs
@@ -219,19 +219,16 @@ namespace ExhaustiveMatching.Analyzer.Tests
         }";
 
             var source = CodeContext.Shapes(args, test);
-            var expected1 = DiagnosticResult
-                            .Error("EM0102", "Exhaustive switch must be on enum or closed type, was on: System.Object")
-                            .AddLocation(source, 1);
 
             // Still reports these errors
-            var expected2 = DiagnosticResult
+            var expected1 = DiagnosticResult
                             .Error("EM0100", "When guard is not supported in an exhaustive switch")
                             .AddLocation(source, 2);
-            var expected3 = DiagnosticResult
+            var expected2 = DiagnosticResult
                             .Error("EM0101", "Case pattern not supported in exhaustive switch: 12")
                             .AddLocation(source, 3);
 
-            await VerifyCSharpDiagnosticsAsync(source, expected1, expected2, expected3);
+            await VerifyCSharpDiagnosticsAsync(source, expected1, expected2);
         }
 
         [Fact]
@@ -458,10 +455,8 @@ namespace TestNamespace
         }";
 
             var source = CodeContext.Basic(args, test);
-            var expected = DiagnosticResult.Error("EM0102", "Exhaustive switch must be on enum or closed type, was on: System.HashCode")
-                                                 .AddLocation(source, 1);
 
-            await VerifyCSharpDiagnosticsAsync(source, expected);
+            await VerifyCSharpDiagnosticsAsync(source);
         }
 
         [Fact]
@@ -482,11 +477,8 @@ namespace TestNamespace
         }";
 
             var source = CodeContext.Basic(args, test);
-            var expected = DiagnosticResult
-                           .Error("EM0102", "Exhaustive switch must be on enum or closed type, was on: System.Nullable")
-                           .AddLocation(source, 1);
 
-            await VerifyCSharpDiagnosticsAsync(source, expected);
+            await VerifyCSharpDiagnosticsAsync(source);
         }
 
         [Fact]
@@ -505,15 +497,12 @@ namespace TestNamespace
         }";
 
             var source = CodeContext.Shapes(args, test);
-            // TODO type name is bad
-            var expected1 = DiagnosticResult
-                            .Error("EM0102", "Exhaustive switch must be on enum or closed type, was on: System.ValueTuple")
-                            .AddLocation(source, 1);
-            var expected2 = DiagnosticResult
+
+            var expected = DiagnosticResult
                             .Error("EM0101", "Case pattern not supported in exhaustive switch: (Square square1, Square square2)")
                             .AddLocation(source, 2);
 
-            await VerifyCSharpDiagnosticsAsync(source, expected1, expected2);
+            await VerifyCSharpDiagnosticsAsync(source, expected);
         }
 
         [Fact]
@@ -533,16 +522,13 @@ namespace TestNamespace
         }";
 
             var source = CodeContext.Shapes(args, test);
-            // TODO type name is bad
-            var expected1 = DiagnosticResult
-                            .Error("EM0102", "Exhaustive switch must be on enum or closed type, was on: System.Nullable")
-                            .AddLocation(source, 1);
-            var expected2 = DiagnosticResult
+
+            var expected = DiagnosticResult
                             .Error("EM0101",
                                 "Case pattern not supported in exhaustive switch: (Square square1, Square square2)")
                             .AddLocation(source, 2);
 
-            await VerifyCSharpDiagnosticsAsync(source, expected1, expected2);
+            await VerifyCSharpDiagnosticsAsync(source, expected);
         }
 
         [Fact]

--- a/ExhaustiveMatching.Analyzer.Tests/Verifiers/DiagnosticVerifier.cs
+++ b/ExhaustiveMatching.Analyzer.Tests/Verifiers/DiagnosticVerifier.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -127,7 +128,7 @@ namespace ExhaustiveMatching.Analyzer.Tests.Verifiers
                         $"Expected diagnostic severity to be \"{expected.Severity}\" was \"{actual.Severity}\"\r\n\r\nDiagnostic:\r\n    {FormatDiagnostics(analyzer, actual)}\r\n");
                 }
 
-                if (actual.GetMessage() != expected.Message)
+                if (actual.GetMessage(CultureInfo.InvariantCulture) != expected.Message)
                 {
                     Assert.True(false,
                         $"Expected diagnostic message to be \"{expected.Message}\" was \"{actual.GetMessage()}\"\r\n\r\nDiagnostic:\r\n    {FormatDiagnostics(analyzer, actual)}\r\n");

--- a/ExhaustiveMatching.Analyzer.Tests/Verifiers/DiagnosticVerifier.cs
+++ b/ExhaustiveMatching.Analyzer.Tests/Verifiers/DiagnosticVerifier.cs
@@ -131,7 +131,7 @@ namespace ExhaustiveMatching.Analyzer.Tests.Verifiers
                 if (actual.GetMessage(CultureInfo.InvariantCulture) != expected.Message)
                 {
                     Assert.True(false,
-                        $"Expected diagnostic message to be \"{expected.Message}\" was \"{actual.GetMessage()}\"\r\n\r\nDiagnostic:\r\n    {FormatDiagnostics(analyzer, actual)}\r\n");
+                        $"Expected diagnostic message to be \"{expected.Message}\" was \"{actual.GetMessage(CultureInfo.InvariantCulture)}\"\r\n\r\nDiagnostic:\r\n    {FormatDiagnostics(analyzer, actual)}\r\n");
                 }
             }
         }

--- a/ExhaustiveMatching.Analyzer.nuspec
+++ b/ExhaustiveMatching.Analyzer.nuspec
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <package>
   <metadata>
-    <id>ExhaustiveMatching.Analyzer</id>
-    <version>0.5.0</version>
+    <id>ExhaustiveMatching.Analyzer.Stek</id>
+    <version>0.5.1</version>
     <authors>Jeff Walker</authors>
     <owners>Jeff Walker</owners>
     <license type="expression">BSD-3-Clause</license>

--- a/ExhaustiveMatching.Analyzer.nuspec
+++ b/ExhaustiveMatching.Analyzer.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ExhaustiveMatching.Analyzer.Stek</id>
-    <version>0.5.4</version>
+    <version>0.5.5</version>
     <authors>Jeff Walker</authors>
     <owners>Jeff Walker</owners>
     <license type="expression">BSD-3-Clause</license>

--- a/ExhaustiveMatching.Analyzer.nuspec
+++ b/ExhaustiveMatching.Analyzer.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ExhaustiveMatching.Analyzer.Stek</id>
-    <version>0.5.3</version>
+    <version>0.5.4</version>
     <authors>Jeff Walker</authors>
     <owners>Jeff Walker</owners>
     <license type="expression">BSD-3-Clause</license>

--- a/ExhaustiveMatching.Analyzer.nuspec
+++ b/ExhaustiveMatching.Analyzer.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ExhaustiveMatching.Analyzer.Stek</id>
-    <version>0.5.5</version>
+    <version>0.5.6</version>
     <authors>Jeff Walker</authors>
     <owners>Jeff Walker</owners>
     <license type="expression">BSD-3-Clause</license>

--- a/ExhaustiveMatching.Analyzer.nuspec
+++ b/ExhaustiveMatching.Analyzer.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ExhaustiveMatching.Analyzer.Stek</id>
-    <version>0.5.1</version>
+    <version>0.5.2</version>
     <authors>Jeff Walker</authors>
     <owners>Jeff Walker</owners>
     <license type="expression">BSD-3-Clause</license>

--- a/ExhaustiveMatching.Analyzer.nuspec
+++ b/ExhaustiveMatching.Analyzer.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ExhaustiveMatching.Analyzer.Stek</id>
-    <version>0.5.2</version>
+    <version>0.5.3</version>
     <authors>Jeff Walker</authors>
     <owners>Jeff Walker</owners>
     <license type="expression">BSD-3-Clause</license>

--- a/ExhaustiveMatching.Analyzer/ExhaustiveMatchAnalyzer.cs
+++ b/ExhaustiveMatching.Analyzer/ExhaustiveMatchAnalyzer.cs
@@ -70,6 +70,7 @@ namespace ExhaustiveMatching.Analyzer
 
         private const string Category = "Logic";
 
+#pragma warning disable RS2008 // Enable analyzer release tracking
         public static readonly DiagnosticDescriptor NotExhaustiveEnumSwitch =
             new DiagnosticDescriptor("EM0001", EM0001Title, EM0001Message, Category,
                 DiagnosticSeverity.Error, isEnabledByDefault: true, EM0001Description);
@@ -125,6 +126,7 @@ namespace ExhaustiveMatching.Analyzer
         public static readonly DiagnosticDescriptor DuplicateCaseType =
             new DiagnosticDescriptor("EM0105", EM0105Title, EM0105Message, Category,
                 DiagnosticSeverity.Error, isEnabledByDefault: true, EM0105Description);
+#pragma warning restore RS2008 // Enable analyzer release tracking
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
             ImmutableArray.Create(NotExhaustiveEnumSwitch, NotExhaustiveNullableEnumSwitch,

--- a/ExhaustiveMatching.Analyzer/ExhaustiveMatchAnalyzer.cs
+++ b/ExhaustiveMatching.Analyzer/ExhaustiveMatchAnalyzer.cs
@@ -52,10 +52,6 @@ namespace ExhaustiveMatching.Analyzer
         private static readonly LocalizableString EM0101Message = LoadString(nameof(Resources.EM0101Message));
         private static readonly LocalizableString EM0101Description = LoadString(Resources.EM0101Description);
 
-        private static readonly LocalizableString EM0102Title = LoadString(nameof(Resources.EM0102Title));
-        private static readonly LocalizableString EM0102Message = LoadString(nameof(Resources.EM0102Message));
-        private static readonly LocalizableString EM0102Description = LoadString(Resources.EM0102Description);
-
         private static readonly LocalizableString EM0103Title = LoadString(nameof(Resources.EM0103Title));
         private static readonly LocalizableString EM0103Message = LoadString(nameof(Resources.EM0103Message));
         private static readonly LocalizableString EM0103Description = LoadString(Resources.EM0103Description);
@@ -111,10 +107,6 @@ namespace ExhaustiveMatching.Analyzer
             new DiagnosticDescriptor("EM0101", EM0101Title, EM0101Message, Category,
                 DiagnosticSeverity.Error, isEnabledByDefault: true, EM0101Description);
 
-        public static readonly DiagnosticDescriptor OpenTypeNotSupported =
-            new DiagnosticDescriptor("EM0102", EM0102Title, EM0102Message, Category,
-                DiagnosticSeverity.Error, isEnabledByDefault: true, EM0102Description);
-
         public static readonly DiagnosticDescriptor MatchMustBeOnCaseType =
             new DiagnosticDescriptor("EM0103", EM0103Title, EM0103Message, Category,
                 DiagnosticSeverity.Error, isEnabledByDefault: true, EM0103Description);
@@ -133,8 +125,8 @@ namespace ExhaustiveMatching.Analyzer
                 NotExhaustiveObjectSwitch, ConcreteSubtypeMustBeCaseOfClosedType,
                 MustBeDirectSubtype, MustBeSubtype, SubtypeMustBeCovered,
                 OpenInterfaceSubtypeMustBeCaseOfClosedType, WhenGuardNotSupported,
-                CasePatternNotSupported, OpenTypeNotSupported, MatchMustBeOnCaseType,
-                DuplicateClosedAttribute, DuplicateCaseType);
+                CasePatternNotSupported, MatchMustBeOnCaseType, DuplicateClosedAttribute,
+                DuplicateCaseType);
 
         public override void Initialize(AnalysisContext context)
         {

--- a/ExhaustiveMatching.Analyzer/ExhaustiveMatchAnalyzer.cs
+++ b/ExhaustiveMatching.Analyzer/ExhaustiveMatchAnalyzer.cs
@@ -52,6 +52,10 @@ namespace ExhaustiveMatching.Analyzer
         private static readonly LocalizableString EM0101Message = LoadString(nameof(Resources.EM0101Message));
         private static readonly LocalizableString EM0101Description = LoadString(Resources.EM0101Description);
 
+        private static readonly LocalizableString EM0102Title = LoadString(nameof(Resources.EM0102Title));
+        private static readonly LocalizableString EM0102Message = LoadString(nameof(Resources.EM0102Message));
+        private static readonly LocalizableString EM0102Description = LoadString(Resources.EM0102Description);
+
         private static readonly LocalizableString EM0103Title = LoadString(nameof(Resources.EM0103Title));
         private static readonly LocalizableString EM0103Message = LoadString(nameof(Resources.EM0103Message));
         private static readonly LocalizableString EM0103Description = LoadString(Resources.EM0103Description);
@@ -107,6 +111,10 @@ namespace ExhaustiveMatching.Analyzer
             new DiagnosticDescriptor("EM0101", EM0101Title, EM0101Message, Category,
                 DiagnosticSeverity.Error, isEnabledByDefault: true, EM0101Description);
 
+        public static readonly DiagnosticDescriptor OpenTypeNotSupported =
+            new DiagnosticDescriptor("EM0102", EM0102Title, EM0102Message, Category,
+                DiagnosticSeverity.Error, isEnabledByDefault: true, EM0102Description);
+
         public static readonly DiagnosticDescriptor MatchMustBeOnCaseType =
             new DiagnosticDescriptor("EM0103", EM0103Title, EM0103Message, Category,
                 DiagnosticSeverity.Error, isEnabledByDefault: true, EM0103Description);
@@ -125,8 +133,8 @@ namespace ExhaustiveMatching.Analyzer
                 NotExhaustiveObjectSwitch, ConcreteSubtypeMustBeCaseOfClosedType,
                 MustBeDirectSubtype, MustBeSubtype, SubtypeMustBeCovered,
                 OpenInterfaceSubtypeMustBeCaseOfClosedType, WhenGuardNotSupported,
-                CasePatternNotSupported, MatchMustBeOnCaseType, DuplicateClosedAttribute,
-                DuplicateCaseType);
+                CasePatternNotSupported, OpenTypeNotSupported, MatchMustBeOnCaseType,
+                DuplicateClosedAttribute, DuplicateCaseType);
 
         public override void Initialize(AnalysisContext context)
         {

--- a/ExhaustiveMatching.Analyzer/ExhaustiveMatching.Analyzer.csproj
+++ b/ExhaustiveMatching.Analyzer/ExhaustiveMatching.Analyzer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <Version>0.5.0</Version>
+    <Version>0.5.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ExhaustiveMatching.Analyzer/ExhaustiveMatching.Analyzer.csproj
+++ b/ExhaustiveMatching.Analyzer/ExhaustiveMatching.Analyzer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <Version>0.5.2</Version>
+    <Version>0.5.3</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ExhaustiveMatching.Analyzer/ExhaustiveMatching.Analyzer.csproj
+++ b/ExhaustiveMatching.Analyzer/ExhaustiveMatching.Analyzer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <Version>0.5.5</Version>
+    <Version>0.5.6</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/ExhaustiveMatching.Analyzer/ExhaustiveMatching.Analyzer.csproj
+++ b/ExhaustiveMatching.Analyzer/ExhaustiveMatching.Analyzer.csproj
@@ -3,14 +3,11 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <AssemblyVersion>0.5.0.0</AssemblyVersion>
-    <FileVersion>0.5.0.0</FileVersion>
     <Version>0.5.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.3.1" PrivateAssets="all" />
-    <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.11.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ExhaustiveMatching.Analyzer/ExhaustiveMatching.Analyzer.csproj
+++ b/ExhaustiveMatching.Analyzer/ExhaustiveMatching.Analyzer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <Version>0.5.3</Version>
+    <Version>0.5.4</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ExhaustiveMatching.Analyzer/ExhaustiveMatching.Analyzer.csproj
+++ b/ExhaustiveMatching.Analyzer/ExhaustiveMatching.Analyzer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <Version>0.5.4</Version>
+    <Version>0.5.5</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ExhaustiveMatching.Analyzer/ExhaustiveMatching.Analyzer.csproj
+++ b/ExhaustiveMatching.Analyzer/ExhaustiveMatching.Analyzer.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <Version>0.5.5</Version>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ExhaustiveMatching.Analyzer/ExhaustiveMatching.Analyzer.csproj
+++ b/ExhaustiveMatching.Analyzer/ExhaustiveMatching.Analyzer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <Version>0.5.1</Version>
+    <Version>0.5.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ExhaustiveMatching.Analyzer/ExpressionAnalyzer.cs
+++ b/ExhaustiveMatching.Analyzer/ExpressionAnalyzer.cs
@@ -17,12 +17,16 @@ namespace ExhaustiveMatching.Analyzer
 
             var exhaustiveMatchFailedExceptionType =
                 context.Compilation.GetTypeByMetadataName(TypeNames.ExhaustiveMatchFailedException);
+            var valueOutOfRangeExceptionType =
+                context.Compilation.GetTypeByMetadataName(TypeNames.ValueOutOfRangeException);
             var invalidEnumArgumentExceptionType =
                 context.Compilation.GetTypeByMetadataName(TypeNames.InvalidEnumArgumentException);
 
             var isExhaustiveMatchFailedException = exceptionType.Equals(exhaustiveMatchFailedExceptionType, SymbolEqualityComparer.Default);
+            var isValueOutOfRangeException = exceptionType.Equals(valueOutOfRangeExceptionType, SymbolEqualityComparer.Default);
             var isInvalidEnumArgumentException = exceptionType.Equals(invalidEnumArgumentExceptionType, SymbolEqualityComparer.Default);
-            var isExhaustive = isExhaustiveMatchFailedException || isInvalidEnumArgumentException;
+
+            var isExhaustive = isExhaustiveMatchFailedException || isValueOutOfRangeException || isInvalidEnumArgumentException;
 
             return new SwitchStatementKind(isExhaustive, isInvalidEnumArgumentException);
         }

--- a/ExhaustiveMatching.Analyzer/ExpressionAnalyzer.cs
+++ b/ExhaustiveMatching.Analyzer/ExpressionAnalyzer.cs
@@ -20,8 +20,8 @@ namespace ExhaustiveMatching.Analyzer
             var invalidEnumArgumentExceptionType =
                 context.Compilation.GetTypeByMetadataName(TypeNames.InvalidEnumArgumentException);
 
-            var isExhaustiveMatchFailedException = exceptionType.Equals(exhaustiveMatchFailedExceptionType);
-            var isInvalidEnumArgumentException = exceptionType.Equals(invalidEnumArgumentExceptionType);
+            var isExhaustiveMatchFailedException = exceptionType.Equals(exhaustiveMatchFailedExceptionType, SymbolEqualityComparer.Default);
+            var isInvalidEnumArgumentException = exceptionType.Equals(invalidEnumArgumentExceptionType, SymbolEqualityComparer.Default);
             var isExhaustive = isExhaustiveMatchFailedException || isInvalidEnumArgumentException;
 
             return new SwitchStatementKind(isExhaustive, isInvalidEnumArgumentException);

--- a/ExhaustiveMatching.Analyzer/PatternAnalyzer.cs
+++ b/ExhaustiveMatching.Analyzer/PatternAnalyzer.cs
@@ -20,6 +20,7 @@ namespace ExhaustiveMatching.Analyzer
                 case DeclarationPatternSyntax declarationPattern:
                     symbolUsed = context.GetDeclarationType(declarationPattern);
                     break;
+                case VarPatternSyntax _:
                 case DiscardPatternSyntax _:
                     // Ignored
                     return null;
@@ -35,7 +36,6 @@ namespace ExhaustiveMatching.Analyzer
 
                     symbolUsed = patternSymbol;
                     break;
-                case VarPatternSyntax _:
                 case RecursivePatternSyntax _:
                 default:
                     context.ReportCasePatternNotSupported(pattern);

--- a/ExhaustiveMatching.Analyzer/PatternAnalyzer.cs
+++ b/ExhaustiveMatching.Analyzer/PatternAnalyzer.cs
@@ -21,10 +21,20 @@ namespace ExhaustiveMatching.Analyzer
                     symbolUsed = context.GetDeclarationType(declarationPattern);
                     break;
                 case DiscardPatternSyntax _:
-                case ConstantPatternSyntax constantPattern
-                    when constantPattern.IsNull():
                     // Ignored
                     return null;
+                case ConstantPatternSyntax constantPattern:
+                    if (constantPattern.IsNull()) {
+                        // Ignored
+                        return null;
+                    }
+
+                    var patternSymbol = context.SemanticModel.GetSymbolInfo(constantPattern.Expression).Symbol as ITypeSymbol;
+                    if (patternSymbol == null)
+                        goto default;
+
+                    symbolUsed = patternSymbol;
+                    break;
                 case VarPatternSyntax _:
                 case RecursivePatternSyntax _:
                 default:

--- a/ExhaustiveMatching.Analyzer/PatternAnalyzer.cs
+++ b/ExhaustiveMatching.Analyzer/PatternAnalyzer.cs
@@ -31,10 +31,8 @@ namespace ExhaustiveMatching.Analyzer
                     }
 
                     var patternSymbol = context.SemanticModel.GetSymbolInfo(constantPattern.Expression).Symbol as ITypeSymbol;
-                    if (patternSymbol == null) {
-                        // Ignored
-                        return null;
-                    }
+                    if (patternSymbol == null)
+                        goto default;
 
                     symbolUsed = patternSymbol;
                     break;

--- a/ExhaustiveMatching.Analyzer/PatternAnalyzer.cs
+++ b/ExhaustiveMatching.Analyzer/PatternAnalyzer.cs
@@ -31,8 +31,10 @@ namespace ExhaustiveMatching.Analyzer
                     }
 
                     var patternSymbol = context.SemanticModel.GetSymbolInfo(constantPattern.Expression).Symbol as ITypeSymbol;
-                    if (patternSymbol == null)
-                        goto default;
+                    if (patternSymbol == null) {
+                        // Ignored
+                        return null;
+                    }
 
                     symbolUsed = patternSymbol;
                     break;

--- a/ExhaustiveMatching.Analyzer/SwitchExpressionAnalyzer.cs
+++ b/ExhaustiveMatching.Analyzer/SwitchExpressionAnalyzer.cs
@@ -42,7 +42,7 @@ namespace ExhaustiveMatching.Analyzer
             SwitchExpressionSyntax switchExpression)
         {
             var discardArm = switchExpression.Arms
-                            .LastOrDefault(a => a.Pattern is DiscardPatternSyntax);
+                            .LastOrDefault(a => a.Pattern is DiscardPatternSyntax || a.Pattern is VarPatternSyntax);
 
             // If there is no discard arm or it doesn't throw, we assume the
             // dev doesn't want an exhaustive match

--- a/ExhaustiveMatching.Analyzer/SwitchExpressionAnalyzer.cs
+++ b/ExhaustiveMatching.Analyzer/SwitchExpressionAnalyzer.cs
@@ -103,6 +103,7 @@ namespace ExhaustiveMatching.Analyzer
             // we still needed to check the switch cases
             if (!isClosed)
             {
+                context.ReportOpenTypeNotSupported(type, switchExpression.GoverningExpression);
                 return; // No point in trying to check for uncovered types, this isn't closed
             }
 

--- a/ExhaustiveMatching.Analyzer/SwitchExpressionAnalyzer.cs
+++ b/ExhaustiveMatching.Analyzer/SwitchExpressionAnalyzer.cs
@@ -103,7 +103,6 @@ namespace ExhaustiveMatching.Analyzer
             // we still needed to check the switch cases
             if (!isClosed)
             {
-                context.ReportOpenTypeNotSupported(type, switchExpression.GoverningExpression);
                 return; // No point in trying to check for uncovered types, this isn't closed
             }
 

--- a/ExhaustiveMatching.Analyzer/SwitchExpressionAnalyzer.cs
+++ b/ExhaustiveMatching.Analyzer/SwitchExpressionAnalyzer.cs
@@ -63,7 +63,7 @@ namespace ExhaustiveMatching.Analyzer
 
             var symbolsUsed = patterns.OfType<ConstantPatternSyntax>()
                               .Select(p => context.GetSymbol(p.Expression))
-                              .ToImmutableHashSet();
+                              .ToImmutableHashSet(SymbolEqualityComparer.Default);
 
             // If null were not required, and there were a null case, that would already be a compile error
             if (nullRequired && !patterns.Any(PatternSyntaxExtensions.IsNull))
@@ -97,7 +97,7 @@ namespace ExhaustiveMatching.Analyzer
             var typesUsed = patterns
                 .Select(pattern => pattern.GetMatchedTypeSymbol(context, type, allCases, isClosed))
                 .Where(t => t != null) // returns null for invalid case clauses
-                .ToImmutableHashSet();
+                .ToImmutableHashSet<ITypeSymbol>(SymbolEqualityComparer.Default);
 
             // If it is an open type, we don't want to actually check for uncovered types, but
             // we still needed to check the switch cases

--- a/ExhaustiveMatching.Analyzer/SwitchStatementAnalyzer.cs
+++ b/ExhaustiveMatching.Analyzer/SwitchStatementAnalyzer.cs
@@ -123,7 +123,6 @@ namespace ExhaustiveMatching.Analyzer
             // we still needed to check the switch cases
             if (!isClosed)
             {
-                context.ReportOpenTypeNotSupported(type, switchStatement.Expression);
                 return; // No point in trying to check for uncovered types, this isn't closed
             }
 

--- a/ExhaustiveMatching.Analyzer/SwitchStatementAnalyzer.cs
+++ b/ExhaustiveMatching.Analyzer/SwitchStatementAnalyzer.cs
@@ -79,7 +79,7 @@ namespace ExhaustiveMatching.Analyzer
 
             var symbolsUsed = caseSwitchLabels
                               .Select(l => context.GetSymbol(l.Value))
-                              .ToImmutableHashSet();
+                              .ToImmutableHashSet(SymbolEqualityComparer.Default);
 
             // If null were not required, and there were a null case, that would already be a compile error
             if (nullRequired && !caseSwitchLabels.Any(IsNullCase))
@@ -117,7 +117,7 @@ namespace ExhaustiveMatching.Analyzer
                 .OfType<CasePatternSwitchLabelSyntax>()
                 .Select(patternLabel => patternLabel.Pattern.GetMatchedTypeSymbol(context, type, allCases, isClosed))
                 .Where(t => t != null) // returns null for invalid case clauses
-                .ToImmutableHashSet();
+                .ToImmutableHashSet<ITypeSymbol>(SymbolEqualityComparer.Default);
 
             // If it is an open type, we don't want to actually check for uncovered types, but
             // we still needed to check the switch cases

--- a/ExhaustiveMatching.Analyzer/SwitchStatementAnalyzer.cs
+++ b/ExhaustiveMatching.Analyzer/SwitchStatementAnalyzer.cs
@@ -53,7 +53,7 @@ namespace ExhaustiveMatching.Analyzer
             if (defaultSectionBlock != null)
                 defaultSectionStatements = defaultSectionBlock.Statements;
 
-            var throwStatement = defaultSectionStatements
+            var throwStatement = defaultSectionStatements?
                                     .OfType<ThrowStatementSyntax>().FirstOrDefault();
 
             // If there is no default section or it doesn't throw, we assume the

--- a/ExhaustiveMatching.Analyzer/SwitchStatementAnalyzer.cs
+++ b/ExhaustiveMatching.Analyzer/SwitchStatementAnalyzer.cs
@@ -47,7 +47,13 @@ namespace ExhaustiveMatching.Analyzer
             var defaultSection = switchStatement.Sections
                 .FirstOrDefault(s => s.Labels.OfType<DefaultSwitchLabelSyntax>().Any());
 
-            var throwStatement = defaultSection?.Statements
+            var defaultSectionStatements = defaultSection?.Statements;
+
+            var defaultSectionBlock = defaultSectionStatements?.OfType<BlockSyntax>().FirstOrDefault();
+            if (defaultSectionBlock != null)
+                defaultSectionStatements = defaultSectionBlock.Statements;
+
+            var throwStatement = defaultSectionStatements
                                     .OfType<ThrowStatementSyntax>().FirstOrDefault();
 
             // If there is no default section or it doesn't throw, we assume the

--- a/ExhaustiveMatching.Analyzer/SwitchStatementAnalyzer.cs
+++ b/ExhaustiveMatching.Analyzer/SwitchStatementAnalyzer.cs
@@ -123,6 +123,7 @@ namespace ExhaustiveMatching.Analyzer
             // we still needed to check the switch cases
             if (!isClosed)
             {
+                context.ReportOpenTypeNotSupported(type, switchStatement.Expression);
                 return; // No point in trying to check for uncovered types, this isn't closed
             }
 

--- a/ExhaustiveMatching.Analyzer/SyntaxNodeAnalysisContextExtensions.cs
+++ b/ExhaustiveMatching.Analyzer/SyntaxNodeAnalysisContextExtensions.cs
@@ -69,6 +69,17 @@ namespace ExhaustiveMatching.Analyzer
             context.ReportDiagnostic(diagnostic);
         }
 
+        public static void ReportOpenTypeNotSupported(
+            this SyntaxNodeAnalysisContext context,
+            ITypeSymbol type,
+            ExpressionSyntax switchStatementExpression)
+        {
+            var diagnostic = Diagnostic.Create(
+                ExhaustiveMatchAnalyzer.OpenTypeNotSupported,
+                switchStatementExpression.GetLocation(), type.GetFullName());
+            context.ReportDiagnostic(diagnostic);
+        }
+
         public static void ReportWhenClauseNotSupported(
             this SyntaxNodeAnalysisContext context,
             WhenClauseSyntax whenClause)

--- a/ExhaustiveMatching.Analyzer/SyntaxNodeAnalysisContextExtensions.cs
+++ b/ExhaustiveMatching.Analyzer/SyntaxNodeAnalysisContextExtensions.cs
@@ -69,17 +69,6 @@ namespace ExhaustiveMatching.Analyzer
             context.ReportDiagnostic(diagnostic);
         }
 
-        public static void ReportOpenTypeNotSupported(
-            this SyntaxNodeAnalysisContext context,
-            ITypeSymbol type,
-            ExpressionSyntax switchStatementExpression)
-        {
-            var diagnostic = Diagnostic.Create(
-                ExhaustiveMatchAnalyzer.OpenTypeNotSupported,
-                switchStatementExpression.GetLocation(), type.GetFullName());
-            context.ReportDiagnostic(diagnostic);
-        }
-
         public static void ReportWhenClauseNotSupported(
             this SyntaxNodeAnalysisContext context,
             WhenClauseSyntax whenClause)

--- a/ExhaustiveMatching.Analyzer/TypeDeclarationAnalyzer.cs
+++ b/ExhaustiveMatching.Analyzer/TypeDeclarationAnalyzer.cs
@@ -50,7 +50,7 @@ namespace ExhaustiveMatching.Analyzer
             foreach (var superType in closedSuperTypes)
             {
                 var isMember = superType.GetCaseTypes(closedAttribute)
-                                .Any(t => t.Equals(typeSymbol));
+                                .Any(t => t.Equals(typeSymbol, SymbolEqualityComparer.Default));
                 if (isMember)
                     continue;
 
@@ -99,7 +99,7 @@ namespace ExhaustiveMatching.Analyzer
               {
                   var constructorSymbol = context.GetSymbol(a);
                   var attributeSymbol = constructorSymbol?.ContainingSymbol;
-                  return closedAttribute.Equals(attributeSymbol);
+                  return closedAttribute.Equals(attributeSymbol, SymbolEqualityComparer.Default);
               }).ToList();
 
             return closedAttributes;
@@ -168,12 +168,12 @@ namespace ExhaustiveMatching.Analyzer
                     var caseType = context.SemanticModel.GetTypeInfo(caseTypeSyntax).Type;
 
                     if (caseType == null
-                        || typeSymbol.Equals(caseType.BaseType) // BaseType is null for interfaces, avoid calling method on it
-                        || caseType.Interfaces.Any(i => i.Equals(typeSymbol)))
+                        || typeSymbol.Equals(caseType.BaseType, SymbolEqualityComparer.Default) // BaseType is null for interfaces, avoid calling method on it
+                        || caseType.Interfaces.Any(i => i.Equals(typeSymbol, SymbolEqualityComparer.Default)))
                         continue;
 
                     if (caseType.InheritsFrom(typeSymbol)
-                        || caseType.AllInterfaces.Any(i => i.Equals(typeSymbol)))
+                        || caseType.AllInterfaces.Any(i => i.Equals(typeSymbol, SymbolEqualityComparer.Default)))
                     {
                         // It's a subtype, just not a direct one
                         var diagnostic = Diagnostic.Create(ExhaustiveMatchAnalyzer.MustBeDirectSubtype,

--- a/ExhaustiveMatching.Analyzer/TypeNames.cs
+++ b/ExhaustiveMatching.Analyzer/TypeNames.cs
@@ -10,6 +10,7 @@ namespace ExhaustiveMatching.Analyzer
     public static class TypeNames
     {
         public const string ExhaustiveMatchFailedException = "ExhaustiveMatching.ExhaustiveMatchFailedException";
+        public const string ValueOutOfRangeException = "Nisse.ValueOutOfRangeException";
         public const string ClosedAttribute = "ExhaustiveMatching.ClosedAttribute";
         public static readonly string InvalidEnumArgumentException = typeof(InvalidEnumArgumentException).FullName;
         public static readonly string Nullable = typeof(System.Nullable<>).FullName;

--- a/ExhaustiveMatching.Analyzer/TypeSymbolExtensions.cs
+++ b/ExhaustiveMatching.Analyzer/TypeSymbolExtensions.cs
@@ -164,9 +164,9 @@ namespace ExhaustiveMatching.Analyzer
             this ITypeSymbol rootType,
             INamedTypeSymbol closedAttributeType)
         {
-#pragma warning disable RS1024
+#pragma warning disable RS1024 // Compare symbols correctly
             var types = new HashSet<ITypeSymbol>(SymbolEqualityComparer.Default);
-#pragma warning restore RS1024
+#pragma warning restore RS1024 // Compare symbols correctly
             var queue = new Queue<ITypeSymbol>();
             queue.Enqueue(rootType);
 

--- a/ExhaustiveMatching.Examples/ExhaustiveMatching.Examples.csproj
+++ b/ExhaustiveMatching.Examples/ExhaustiveMatching.Examples.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Examples</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ExhaustiveMatching.Analyzer" Version="0.4.0" />
+    <PackageReference Include="ExhaustiveMatching.Analyzer" Version="0.5.0" />
   </ItemGroup>
 
 </Project>

--- a/ExhaustiveMatching.Examples/ReadMe/IPAddressExample.cs
+++ b/ExhaustiveMatching.Examples/ReadMe/IPAddressExample.cs
@@ -20,7 +20,9 @@ namespace Examples.ReadMe
         {
             #region snippet
             // ERROR Subtype not handled by switch: IPv6Address
+#pragma warning disable EM0003
             switch (ipAddress)
+#pragma warning restore EM0003
             {
                 default:
                     throw ExhaustiveMatch.Failed(ipAddress);

--- a/ExhaustiveMatching.Tests/ExhaustiveMatching.Tests.csproj
+++ b/ExhaustiveMatching.Tests/ExhaustiveMatching.Tests.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/ExhaustiveMatching/ExhaustiveMatching.csproj
+++ b/ExhaustiveMatching/ExhaustiveMatching.csproj
@@ -2,15 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyVersion>0.5.0.0</AssemblyVersion>
-    <FileVersion>0.5.0.0</FileVersion>
     <Version>0.5.0</Version>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\..\Program Files\dotnet\sdk\NuGetFallbackFolder\system.collections.immutable\1.5.0\lib\netstandard1.3\System.Collections.Immutable.dll</HintPath>
-    </Reference>
-  </ItemGroup>
 
 </Project>

--- a/ExhaustiveMatching/ExhaustiveMatching.csproj
+++ b/ExhaustiveMatching/ExhaustiveMatching.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.5.2</Version>
+    <Version>0.5.3</Version>
   </PropertyGroup>
 
 </Project>

--- a/ExhaustiveMatching/ExhaustiveMatching.csproj
+++ b/ExhaustiveMatching/ExhaustiveMatching.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.5.4</Version>
+    <Version>0.5.5</Version>
   </PropertyGroup>
 
 </Project>

--- a/ExhaustiveMatching/ExhaustiveMatching.csproj
+++ b/ExhaustiveMatching/ExhaustiveMatching.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.5.0</Version>
+    <Version>0.5.1</Version>
   </PropertyGroup>
 
 </Project>

--- a/ExhaustiveMatching/ExhaustiveMatching.csproj
+++ b/ExhaustiveMatching/ExhaustiveMatching.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.5.3</Version>
+    <Version>0.5.4</Version>
   </PropertyGroup>
 
 </Project>

--- a/ExhaustiveMatching/ExhaustiveMatching.csproj
+++ b/ExhaustiveMatching/ExhaustiveMatching.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.5.5</Version>
+    <Version>0.5.6</Version>
   </PropertyGroup>
 
 </Project>

--- a/ExhaustiveMatching/ExhaustiveMatching.csproj
+++ b/ExhaustiveMatching/ExhaustiveMatching.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.5.1</Version>
+    <Version>0.5.2</Version>
   </PropertyGroup>
 
 </Project>

--- a/pack.bat
+++ b/pack.bat
@@ -1,2 +1,2 @@
+dotnet build -c Release
 .\tools\nuget.exe pack ExhaustiveMatching.Analyzer.nuspec
-PAUSE


### PR DESCRIPTION
I believe that using var pattern as default (discard) clause in switch expressions is a very nice practice.
Since you don't have to repeat the expression being matched in exception argument or for any other purpose you use it.

So code like
`result.State.Kind switch {
    ...
    _ => throw ExhaustiveMatch.Failed(result.State.Kind);
}`

becomes
`result.State.Kind switch {
    ...
    var k => throw ExhaustiveMatch.Failed(k);
}`

Which seems more clear and less error-prone to me.

This pattern matches any value, be it null or anything else. Moreover, compiler doesn't allow using both var pattern and discard pattern in single switch expression, so this shouldn't cause any trouble for existing code using this library.