### PR TITLE
Implement support for structurally detectable closed hierarchcies (#42)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ obj/
 bin/
 *.nupkg
 *.user
+_ReSharper.Caches/

--- a/ExhaustiveMatching.Analyzer.Tests/CodeContext.cs
+++ b/ExhaustiveMatching.Analyzer.Tests/CodeContext.cs
@@ -63,5 +63,39 @@ namespace TestNamespace
 }}";
             return string.Format(context, args, body);
         }
+
+        public static string Result(string args, string body)
+        {
+            const string context = @"using System; // Result type
+using System;
+using System.Collections.Generic;
+using ExhaustiveMatching;
+using TestNamespace;
+
+class TestClass
+{{
+    void TestMethod({0})
+    {{{1}
+    }}
+}}
+
+namespace TestNamespace
+{{
+    public abstract class Result<TSuccess, TError> {{
+        private Result() {{ }}
+
+        public sealed class Success : Result<TSuccess, TError> {{
+            public TSuccess Value {{ get; }}
+            public Success(TSuccess value) {{ Value = value; }}
+        }}
+
+        public sealed class Error : Result<TSuccess, TError> {{
+            public TError Value {{ get; }}
+            public Error(TError value) {{ Value = value; }}
+        }}
+    }}
+}}";
+            return string.Format(context, args, body);
+        }
     }
 }

--- a/ExhaustiveMatching.Analyzer.Tests/SwitchExpressionAnalyzerTests.cs
+++ b/ExhaustiveMatching.Analyzer.Tests/SwitchExpressionAnalyzerTests.cs
@@ -342,6 +342,60 @@ namespace TestNamespace
         }
 
         [Fact]
+        public async Task SwitchOnStructurallyClosedThrowingExhaustiveMatchFailedIsNotExhaustiveReportsDiagnostic()
+        {
+            const string args = "Result<string, string> result";
+            const string test = @"
+        var x = result ◊1⟦switch⟧
+        {
+            Result<string, string>.Error error => ""Error: "" + error,
+            _ => throw ExhaustiveMatch.Failed(result),
+        };";
+
+            var source = CodeContext.Result(args, test);
+            var expectedSuccess = DiagnosticResult
+                .Error("EM0003", "Subtype not handled by switch: TestNamespace.Success")
+                .AddLocation(source, 1);
+
+            await VerifyCSharpDiagnosticsAsync(source, expectedSuccess);
+        }
+
+        [Fact]
+        public async Task SwitchOnStructurallyClosedThrowingExhaustiveMatchDoesNotReportsDiagnostic()
+        {
+            const string args = "Result<string, string> result";
+            const string test = @"
+        var x = result ◊1⟦switch⟧
+        {
+            Result<string, string>.Error error => ""Error: "" + error,
+            Result<string, string>.Success success => ""Success: "" + success,
+            _ => throw ExhaustiveMatch.Failed(result),
+        };";
+
+            var source = CodeContext.Result(args, test);
+
+            await VerifyCSharpDiagnosticsAsync(source);
+        }
+
+        [Fact]
+        public async Task SwitchOnStructurallyClosedThrowingExhaustiveMatchAllowNull()
+        {
+            const string args = "Result<string, string> result";
+            const string test = @"
+        var x = result ◊1⟦switch⟧
+        {
+            Result<string, string>.Error error => ""Error: "" + error,
+            Result<string, string>.Success success => ""Success: "" + success,
+            null => ""null"",
+            _ => throw ExhaustiveMatch.Failed(result),
+        };";
+
+            var source = CodeContext.Result(args, test);
+
+            await VerifyCSharpDiagnosticsAsync(source);
+        }
+
+        [Fact]
         public async Task SwitchOnStruct()
         {
             const string args = "HashCode hashCode";

--- a/ExhaustiveMatching.Analyzer.Tests/SwitchStatementAnalyzerTests.cs
+++ b/ExhaustiveMatching.Analyzer.Tests/SwitchStatementAnalyzerTests.cs
@@ -444,6 +444,75 @@ namespace TestNamespace
 
 
         [Fact]
+        public async Task SwitchOnStructurallyClosedThrowingExhaustiveMatchFailedIsNotExhaustiveReportsDiagnostic()
+        {
+            const string args = "Result<string, string> result";
+            const string test = @"
+        ◊1⟦switch⟧ (result)
+        {
+            case Result<string, string>.Error error:
+                Console.WriteLine(""Error: "" + error);
+                break;
+            default:
+                throw ExhaustiveMatch.Failed(result);
+        }";
+
+            var source = CodeContext.Result(args, test);
+            var expectedSuccess = DiagnosticResult
+                .Error("EM0003", "Subtype not handled by switch: TestNamespace.Success")
+                .AddLocation(source, 1);
+
+            await VerifyCSharpDiagnosticsAsync(source, expectedSuccess);
+        }
+
+        [Fact]
+        public async Task SwitchOnStructurallyClosedThrowingExhaustiveMatchDoesNotReportsDiagnostic()
+        {
+            const string args = "Result<string, string> result";
+            const string test = @"
+        ◊1⟦switch⟧ (result)
+        {
+            case Result<string, string>.Error error:
+                Console.WriteLine(""Error: "" + error);
+                break;
+            case Result<string, string>.Success success:
+                Console.WriteLine(""Success: "" + success);
+                break;
+            default:
+                throw ExhaustiveMatch.Failed(result);
+        }";
+
+            var source = CodeContext.Result(args, test);
+
+            await VerifyCSharpDiagnosticsAsync(source);
+        }
+
+        [Fact]
+        public async Task SwitchOnStructurallyClosedThrowingExhaustiveMatchAllowNull()
+        {
+            const string args = "Result<string, string> result";
+            const string test = @"
+        ◊1⟦switch⟧ (result)
+        {
+            case Result<string, string>.Error error:
+                Console.WriteLine(""Error: "" + error);
+                break;
+            case Result<string, string>.Success success:
+                Console.WriteLine(""Success: "" + success);
+                break;
+            case null:
+                Console.WriteLine(""null"");
+                break;
+            default:
+                throw ExhaustiveMatch.Failed(result);
+        }";
+
+            var source = CodeContext.Result(args, test);
+
+            await VerifyCSharpDiagnosticsAsync(source);
+        }
+
+        [Fact]
         public async Task SwitchOnStruct()
         {
             const string args = "HashCode hashCode";

--- a/ExhaustiveMatching.Analyzer.Tests/Verifiers/DiagnosticVerifier.cs
+++ b/ExhaustiveMatching.Analyzer.Tests/Verifiers/DiagnosticVerifier.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -14,6 +15,12 @@ namespace ExhaustiveMatching.Analyzer.Tests.Verifiers
     /// </summary>
     public abstract partial class DiagnosticVerifier
     {
+        static DiagnosticVerifier()
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
+        }
+
         #region To be implemented by Test classes
         /// <summary>
         /// Get the CSharp analyzer being tested - to be implemented in non-abstract class

--- a/ExhaustiveMatching.Analyzer/SwitchExpressionAnalyzer.cs
+++ b/ExhaustiveMatching.Analyzer/SwitchExpressionAnalyzer.cs
@@ -93,6 +93,15 @@ namespace ExhaustiveMatching.Analyzer
             var isClosed = type.HasAttribute(closedAttributeType);
 
             var allCases = type.GetClosedTypeCases(closedAttributeType);
+            var allConcreteTypes = allCases
+                .Where(t => t.IsConcreteOrLeaf(closedAttributeType));
+
+            if (!isClosed && type.TryGetStructurallyClosedTypeCases(context, out allCases))
+            {
+                isClosed = true;
+                allConcreteTypes = allCases
+                    .Where(t => t.IsConcrete());
+            }
 
             var typesUsed = patterns
                 .Select(pattern => pattern.GetMatchedTypeSymbol(context, type, allCases, isClosed))
@@ -107,8 +116,7 @@ namespace ExhaustiveMatching.Analyzer
                 return; // No point in trying to check for uncovered types, this isn't closed
             }
 
-            var uncoveredTypes = allCases
-                .Where(t => t.IsConcreteOrLeaf(closedAttributeType))
+            var uncoveredTypes = allConcreteTypes
                 .Where(t => !typesUsed.Any(t.IsSubtypeOf))
                 .ToArray();
 

--- a/ExhaustiveMatching.Analyzer/SwitchStatementAnalyzer.cs
+++ b/ExhaustiveMatching.Analyzer/SwitchStatementAnalyzer.cs
@@ -106,6 +106,15 @@ namespace ExhaustiveMatching.Analyzer
             var isClosed = type.HasAttribute(closedAttributeType);
 
             var allCases = type.GetClosedTypeCases(closedAttributeType);
+            var allConcreteTypes = allCases
+                .Where(t => t.IsConcreteOrLeaf(closedAttributeType));
+
+            if (!isClosed && type.TryGetStructurallyClosedTypeCases(context, out allCases))
+            {
+                isClosed = true;
+                allConcreteTypes = allCases
+                    .Where(t => t.IsConcrete());
+            }
 
             var typesUsed = switchLabels
                 .OfType<CasePatternSwitchLabelSyntax>()
@@ -121,8 +130,7 @@ namespace ExhaustiveMatching.Analyzer
                 return; // No point in trying to check for uncovered types, this isn't closed
             }
 
-            var uncoveredTypes = allCases
-                .Where(t => t.IsConcreteOrLeaf(closedAttributeType))
+            var uncoveredTypes = allConcreteTypes
                 .Where(t => !typesUsed.Any(t.IsSubtypeOf))
                 .ToArray();
 

--- a/ExhaustiveMatching.Examples/Result.cs
+++ b/ExhaustiveMatching.Examples/Result.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+
+namespace Examples {
+    public abstract class Result<TSuccess, TError> : IEquatable<Result<TSuccess, TError>>
+    {
+        private Result() { }
+
+        public sealed class Success : Result<TSuccess, TError>
+        {
+            public TSuccess Value { get; }
+
+            public Success(TSuccess value) { Value = value; }
+
+            public override bool Equals(Result<TSuccess, TError> other)
+            {
+                return other is Success success && EqualityComparer<TSuccess>.Default.Equals(Value, success.Value);
+            }
+
+            public override int GetHashCode()
+            {
+                return EqualityComparer<TSuccess>.Default.GetHashCode(Value);
+            }
+        }
+
+        public sealed class Error : Result<TSuccess, TError>
+        {
+            public TError Value { get; }
+
+            public Error(TError value) { Value = value; }
+
+            public override bool Equals(Result<TSuccess, TError> other)
+            {
+                return other is Error error && EqualityComparer<TError>.Default.Equals(Value, error.Value);
+            }
+
+            public override int GetHashCode()
+            {
+                return EqualityComparer<TError>.Default.GetHashCode(Value);
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is Result<TSuccess, TError> result && Equals(result);
+        }
+
+        public abstract override int GetHashCode();
+
+        public abstract bool Equals(Result<TSuccess, TError> other);
+
+        public static bool operator ==(Result<TSuccess, TError> left, Result<TSuccess, TError> right)
+        {
+            return Equals(left, right);
+        }
+
+        public static bool operator !=(Result<TSuccess, TError> left, Result<TSuccess, TError> right)
+        {
+            return !Equals(left, right);
+        }
+    }
+}


### PR DESCRIPTION
Detecting closed hierarchies like discriminated unions without the need to
provide [Closed]-Attribute