### PR TITLE
Adding C# 8.0 nullable annotations. Addressing code analysis warnings.

### DIFF
--- a/ExhaustiveMatching.Analyzer.Enums/ExhaustiveMatchEnumAnalyzer.cs
+++ b/ExhaustiveMatching.Analyzer.Enums/ExhaustiveMatchEnumAnalyzer.cs
@@ -17,8 +17,7 @@ namespace ExhaustiveMatching.Analyzer.Enums
         public override void Initialize(AnalysisContext context)
         {
             context.EnableConcurrentExecution();
-            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze
-                                                   | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
             context.RegisterSyntaxNodeAction(AnalyzeSwitchStatement, SyntaxKind.SwitchStatement);
             //context.RegisterSyntaxNodeAction(AnalyzeSwitchExpression, SyntaxKind.SwitchExpression);
         }
@@ -37,7 +36,7 @@ namespace ExhaustiveMatching.Analyzer.Enums
                 // Include stack trace info by ToString() the exception as part of the message.
                 // Only the first line is included, so we have to remove newlines
                 var exDetails = Regex.Replace(ex.ToString(), @"\r\n?|\n|\r", " ");
-                throw new Exception($"Uncaught exception in analyzer: {exDetails}");
+                throw new Exception($"Uncaught exception in analyzer: {exDetails}", innerException: ex);
             }
         }
     }

--- a/ExhaustiveMatching.Analyzer.Enums/ExhaustiveMatching.Analyzer.Enums.csproj
+++ b/ExhaustiveMatching.Analyzer.Enums/ExhaustiveMatching.Analyzer.Enums.csproj
@@ -1,11 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;</TargetFrameworks>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.3.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ExhaustiveMatching.Analyzer.Enums/Semantics/SyntaxNodeAnalysisContextExtensions.cs
+++ b/ExhaustiveMatching.Analyzer.Enums/Semantics/SyntaxNodeAnalysisContextExtensions.cs
@@ -9,7 +9,7 @@ namespace ExhaustiveMatching.Analyzer.Enums.Semantics
         /// <summary>
         /// Get the type of an expression.
         /// </summary>
-        public static ITypeSymbol GetExpressionType(
+        public static ITypeSymbol? GetExpressionType(
             this SyntaxNodeAnalysisContext context,
             ExpressionSyntax switchStatementExpression)
             => context.SemanticModel.GetTypeInfo(switchStatementExpression, context.CancellationToken).Type;
@@ -17,12 +17,12 @@ namespace ExhaustiveMatching.Analyzer.Enums.Semantics
         /// <summary>
         /// Get the converted type of an expression.
         /// </summary>
-        public static ITypeSymbol GetExpressionConvertedType(
+        public static ITypeSymbol? GetExpressionConvertedType(
             this SyntaxNodeAnalysisContext context,
             ExpressionSyntax switchStatementExpression) =>
             context.SemanticModel.GetTypeInfo(switchStatementExpression, context.CancellationToken).ConvertedType;
 
-        public static ISymbol GetSymbol(this SyntaxNodeAnalysisContext context, ExpressionSyntax expression)
+        public static ISymbol? GetSymbol(this SyntaxNodeAnalysisContext context, ExpressionSyntax expression)
             => context.SemanticModel.GetSymbolInfo(expression, context.CancellationToken).Symbol;
     }
 }

--- a/ExhaustiveMatching.Analyzer.Enums/Semantics/TypeSymbolExtensions.cs
+++ b/ExhaustiveMatching.Analyzer.Enums/Semantics/TypeSymbolExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.ComponentModel;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -20,7 +21,7 @@ namespace ExhaustiveMatching.Analyzer.Enums.Semantics
         public static bool IsEnum(
             this ITypeSymbol type,
             SyntaxNodeAnalysisContext context,
-            out INamedTypeSymbol enumType,
+            [NotNullWhen(true)] out INamedTypeSymbol? enumType,
             out bool nullable)
         {
             switch (type.TypeKind)
@@ -31,7 +32,7 @@ namespace ExhaustiveMatching.Analyzer.Enums.Semantics
                     return true;
                 case TypeKind.Struct:
                     var nullableType = context.Compilation.GetTypeByMetadataName(TypeNames.Nullable);
-                    if (type.OriginalDefinition.Equals(nullableType))
+                    if (SymbolEqualityComparer.IncludeNullability.Equals(type.OriginalDefinition, nullableType))
                     {
                         type = ((INamedTypeSymbol)type).TypeArguments.Single();
                         if (type.TypeKind == TypeKind.Enum)

--- a/ExhaustiveMatching.Analyzer.Enums/Syntax/ThrowStatementSyntaxExtensions.cs
+++ b/ExhaustiveMatching.Analyzer.Enums/Syntax/ThrowStatementSyntaxExtensions.cs
@@ -8,12 +8,13 @@ namespace ExhaustiveMatching.Analyzer.Enums.Syntax
     public static class ThrowStatementSyntaxExtensions
     {
         /// <summary>
-        /// The type of the expression being thrown.
+        /// Returns the <see cref="ITypeParameterSymbol"/> for type being thrown by <paramref name="throwStatement"/>, if determinable, otherwise <see langword="null"/>.
         /// </summary>
         /// <returns>The type being thrown or <see langword="null"/> if it can't
         /// be determined (e.g. compile error).</returns>
-        public static ITypeSymbol ThrowsType(this ThrowStatementSyntax throwStatement, SyntaxNodeAnalysisContext context)
+        public static ITypeSymbol? ThrowsType(this ThrowStatementSyntax throwStatement, SyntaxNodeAnalysisContext context)
         {
+            if (throwStatement.Expression is null) return null;
             var exceptionType = context.GetExpressionType(throwStatement.Expression);
             if (exceptionType == null || exceptionType is IErrorTypeSymbol)
                 return null;

--- a/ExhaustiveMatching.Analyzer.Enums/Utility/EnumerableExtensions.cs
+++ b/ExhaustiveMatching.Analyzer.Enums/Utility/EnumerableExtensions.cs
@@ -5,14 +5,8 @@ namespace ExhaustiveMatching.Analyzer.Enums.Utility
 {
     public static class EnumerableExtensions
     {
-        public static HashSet<T> ToHashSet<T>(this IEnumerable<T> values)
-            => new HashSet<T>(values);
+        public static IReadOnlyList<T> ToReadOnlyList<T>(this IEnumerable<T> values) => values.ToList();
 
-        public static IReadOnlyList<T> ToReadOnlyList<T>(this IEnumerable<T> values)
-            => values.ToList().AsReadOnly();
-
-        public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T> values)
-            where T : class
-            => values.Where(v => v != null);
+        public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> values) where T : class => values.Where(v => v != null)!;
     }
 }

--- a/ExhaustiveMatching.Analyzer.Enums/Utility/NullableAttributes.cs
+++ b/ExhaustiveMatching.Analyzer.Enums/Utility/NullableAttributes.cs
@@ -1,0 +1,209 @@
+﻿// https://www.meziantou.net/how-to-use-nullable-reference-types-in-dotnet-standard-2-0-and-dotnet-.htm
+// https://github.com/dotnet/runtime/blob/527f9ae88a0ee216b44d556f9bdc84037fe0ebda/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
+
+#pragma warning disable
+#define INTERNAL_NULLABLE_ATTRIBUTES
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+#if NETSTANDARD2_0 ||  NETCOREAPP2_0 ||  NETCOREAPP2_1 ||  NETCOREAPP2_2 || NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
+    /// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class AllowNullAttribute : Attribute
+    { }
+
+    /// <summary>Specifies that null is disallowed as an input even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class DisallowNullAttribute : Attribute
+    { }
+
+    /// <summary>Specifies that an output may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class MaybeNullAttribute : Attribute
+    { }
+
+    /// <summary>Specifies that an output will not be null even if the corresponding type allows it. Specifies that an input argument was not null when the call returns.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class NotNullAttribute : Attribute
+    { }
+
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class MaybeNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter may be null.
+        /// </param>
+        public MaybeNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class NotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+    /// <summary>Specifies that the output will be non-null if the named parameter is non-null.</summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class NotNullIfNotNullAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the associated parameter name.</summary>
+        /// <param name="parameterName">
+        /// The associated parameter name.  The output will be non-null if the argument to the parameter specified is non-null.
+        /// </param>
+        public NotNullIfNotNullAttribute(string parameterName) => ParameterName = parameterName;
+
+        /// <summary>Gets the associated parameter name.</summary>
+        public string ParameterName { get; }
+    }
+
+    /// <summary>Applied to a method that will never return under any circumstance.</summary>
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class DoesNotReturnAttribute : Attribute
+    { }
+
+    /// <summary>Specifies that the method will not return if the associated Boolean parameter is passed the specified value.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class DoesNotReturnIfAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified parameter value.</summary>
+        /// <param name="parameterValue">
+        /// The condition parameter value. Code after the method will be considered unreachable by diagnostics if the argument to
+        /// the associated parameter matches this value.
+        /// </param>
+        public DoesNotReturnIfAttribute(bool parameterValue) => ParameterValue = parameterValue;
+
+        /// <summary>Gets the condition parameter value.</summary>
+        public bool ParameterValue { get; }
+    }
+#endif
+
+#if NETSTANDARD2_0 ||  NETCOREAPP2_0 ||  NETCOREAPP2_1 ||  NETCOREAPP2_2 || NETCOREAPP3_0 || NETCOREAPP3_1 || NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
+    /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values.</summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class MemberNotNullAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with a field or property member.</summary>
+        /// <param name="member">
+        /// The field or property member that is promised to be not-null.
+        /// </param>
+        public MemberNotNullAttribute(string member) => Members = new[] { member };
+
+        /// <summary>Initializes the attribute with the list of field and property members.</summary>
+        /// <param name="members">
+        /// The list of field and property members that are promised to be not-null.
+        /// </param>
+        public MemberNotNullAttribute(params string[] members) => Members = members;
+
+        /// <summary>Gets field or property member names.</summary>
+        public string[] Members { get; }
+    }
+
+    /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values when returning with the specified return value condition.</summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class MemberNotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition and a field or property member.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        /// <param name="member">
+        /// The field or property member that is promised to be not-null.
+        /// </param>
+        public MemberNotNullWhenAttribute(bool returnValue, string member)
+        {
+            ReturnValue = returnValue;
+            Members = new[] { member };
+        }
+
+        /// <summary>Initializes the attribute with the specified return value condition and list of field and property members.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        /// <param name="members">
+        /// The list of field and property members that are promised to be not-null.
+        /// </param>
+        public MemberNotNullWhenAttribute(bool returnValue, params string[] members)
+        {
+            ReturnValue = returnValue;
+            Members = members;
+        }
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+
+        /// <summary>Gets field or property member names.</summary>
+        public string[] Members { get; }
+    }
+#endif
+}

--- a/ExhaustiveMatching.Analyzer.nuspec
+++ b/ExhaustiveMatching.Analyzer.nuspec
@@ -2,8 +2,8 @@
 <package>
   <metadata>
     <id>ExhaustiveMatching.Analyzer</id>
-    <version>0.5.0</version>
-    <authors>Jeff Walker</authors>
+    <version>0.6.0-dev</version>
+    <authors>Jeff Walker + Contributors</authors>
     <owners>Jeff Walker</owners>
     <license type="expression">BSD-3-Clause</license>
     <projectUrl>https://github.com/WalkerCodeRanger/ExhaustiveMatching</projectUrl>
@@ -20,7 +20,7 @@ ExhaustiveMatching.Analyzer goes beyond what other languages support by handling
 hierarchies.
     </description>
     <releaseNotes></releaseNotes>
-    <copyright>Copyright 2019 Jeff Walker</copyright>
+    <copyright>Copyright 2019-2023 Jeff Walker, Contributors</copyright>
     <tags>analyzers, switch, exhaustive, match, discriminated, union, sum-type</tags>
   </metadata>
   <files>

--- a/ExhaustiveMatching.Analyzer/ExhaustiveMatching.Analyzer.csproj
+++ b/ExhaustiveMatching.Analyzer/ExhaustiveMatching.Analyzer.csproj
@@ -1,7 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;</TargetFrameworks>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <AssemblyVersion>0.5.0.0</AssemblyVersion>
     <FileVersion>0.5.0.0</FileVersion>

--- a/ExhaustiveMatching.Analyzer/ExpressionAnalyzer.cs
+++ b/ExhaustiveMatching.Analyzer/ExpressionAnalyzer.cs
@@ -13,7 +13,7 @@ namespace ExhaustiveMatching.Analyzer
         {
             var exceptionType = context.SemanticModel.GetTypeInfo(thrownExpression, context.CancellationToken).Type;
             if (exceptionType == null || exceptionType.TypeKind == TypeKind.Error)
-                return new SwitchStatementKind(false, false);
+                return new SwitchStatementKind(isExhaustive: false, throwsInvalidEnum: false);
 
             // TODO GetTypeByMetadataName returns null if multiple types match. This isn't the way to do this
             var exhaustiveMatchFailedExceptionType =

--- a/ExhaustiveMatching.Analyzer/ExpressionAnalyzer.cs
+++ b/ExhaustiveMatching.Analyzer/ExpressionAnalyzer.cs
@@ -1,3 +1,5 @@
+using ExhaustiveMatching.Analyzer.Semantics;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -21,8 +23,8 @@ namespace ExhaustiveMatching.Analyzer
             var invalidEnumArgumentExceptionType =
                 context.Compilation.GetTypeByMetadataName(TypeNames.InvalidEnumArgumentException);
 
-            var isExhaustiveMatchFailedException = exceptionType.Equals(exhaustiveMatchFailedExceptionType, SymbolEqualityComparer.IncludeNullability);
-            var isInvalidEnumArgumentException = exceptionType.Equals(invalidEnumArgumentExceptionType, SymbolEqualityComparer.IncludeNullability);
+            var isExhaustiveMatchFailedException = exceptionType.EqualsConsideringNullability(exhaustiveMatchFailedExceptionType);
+            var isInvalidEnumArgumentException = exceptionType.EqualsConsideringNullability(invalidEnumArgumentExceptionType);
             var isExhaustive = isExhaustiveMatchFailedException || isInvalidEnumArgumentException;
 
             return new SwitchStatementKind(isExhaustive, isInvalidEnumArgumentException);

--- a/ExhaustiveMatching.Analyzer/PatternAnalyzer.cs
+++ b/ExhaustiveMatching.Analyzer/PatternAnalyzer.cs
@@ -9,7 +9,7 @@ namespace ExhaustiveMatching.Analyzer
 {
     internal static class PatternAnalyzer
     {
-        public static ITypeSymbol GetMatchedTypeSymbol(
+        public static ITypeSymbol? GetMatchedTypeSymbol(
             this SwitchLabelSyntax switchLabel,
             SyntaxNodeAnalysisContext context,
             ITypeSymbol type,
@@ -27,14 +27,14 @@ namespace ExhaustiveMatching.Analyzer
             }
         }
 
-        public static ITypeSymbol GetMatchedTypeSymbol(
+        public static ITypeSymbol? GetMatchedTypeSymbol(
             this PatternSyntax pattern,
             SyntaxNodeAnalysisContext context,
             ITypeSymbol type,
             HashSet<ITypeSymbol> allCases,
             bool isClosed)
         {
-            ITypeSymbol symbolUsed;
+            ITypeSymbol? symbolUsed;
             switch (pattern)
             {
                 case DeclarationPatternSyntax declarationPattern:
@@ -55,7 +55,7 @@ namespace ExhaustiveMatching.Analyzer
                     return null;
             }
 
-            if (isClosed && !allCases.Contains(symbolUsed))
+            if (isClosed && symbolUsed != null && !allCases.Contains(symbolUsed))
             {
                 var diagnostic = Diagnostic.Create(Diagnostics.MatchMustBeOnCaseType,
                     pattern.GetLocation(), symbolUsed.GetFullName(), type.GetFullName());

--- a/ExhaustiveMatching.Analyzer/Semantics/SymbolExtensions.cs
+++ b/ExhaustiveMatching.Analyzer/Semantics/SymbolExtensions.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 using Microsoft.CodeAnalysis;
 
 namespace ExhaustiveMatching.Analyzer.Semantics
@@ -8,6 +10,18 @@ namespace ExhaustiveMatching.Analyzer.Semantics
         {
             var ns = symbol.ContainingNamespace;
             return ns != null && !ns.IsGlobalNamespace ? $"{ns.GetFullName()}.{symbol.Name}" : symbol.Name;
+        }
+
+        /// <summary>Compares <see cref="ITypeSymbol"/> using <see cref="SymbolEqualityComparer.Default"/>, in accordance with <see href="https://github.com/dotnet/roslyn-analyzers/blob/cc67474108c080ea69af95bc193734a4dca65ee3/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/CompareSymbolsCorrectlyAnalyzer.cs#L17">RS1024</see>.</summary>
+        public static bool EqualsDisregardingNullability(this ISymbol symbol, [NotNullWhen(true)] ISymbol? other)
+        {
+            return SymbolEqualityComparer.Default.Equals(symbol, other);
+        }
+
+        /// <summary>Compares <see cref="ITypeSymbol"/> using <see cref="SymbolEqualityComparer.IncludeNullability"/>, in accordance with <see href="https://github.com/dotnet/roslyn-analyzers/blob/cc67474108c080ea69af95bc193734a4dca65ee3/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/CompareSymbolsCorrectlyAnalyzer.cs#L17">RS1024</see>.</summary>
+        public static bool EqualsConsideringNullability(this ISymbol symbol, [NotNullWhen(true)] ISymbol? other)
+        {
+            return SymbolEqualityComparer.IncludeNullability.Equals(symbol, other);
         }
     }
 }

--- a/ExhaustiveMatching.Analyzer/Semantics/SyntaxNodeAnalysisContextExtensions.cs
+++ b/ExhaustiveMatching.Analyzer/Semantics/SyntaxNodeAnalysisContextExtensions.cs
@@ -6,7 +6,7 @@ namespace ExhaustiveMatching.Analyzer.Semantics
 {
     public static class SyntaxNodeAnalysisContextExtensions
     {
-        public static ISymbol GetSymbol(this SyntaxNodeAnalysisContext context, AttributeSyntax attribute) =>
+        public static ISymbol? GetSymbol(this SyntaxNodeAnalysisContext context, AttributeSyntax attribute) =>
             context.SemanticModel.GetSymbolInfo(attribute, context.CancellationToken).Symbol;
     }
 }

--- a/ExhaustiveMatching.Analyzer/Semantics/TypeSymbolExtensions.cs
+++ b/ExhaustiveMatching.Analyzer/Semantics/TypeSymbolExtensions.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using ExhaustiveMatching.Analyzer.Utility;
 using Microsoft.CodeAnalysis;
@@ -11,12 +12,12 @@ namespace ExhaustiveMatching.Analyzer.Semantics
     {
         public static bool IsSubtypeOf(this ITypeSymbol symbol, ITypeSymbol type)
         {
-            return symbol.Equals(type) || symbol.Implements(type) || symbol.InheritsFrom(type);
+            return symbol.EqualsDisregardingNullability(type) || symbol.Implements(type) || symbol.InheritsFrom(type);
         }
 
         public static bool IsDirectSubtypeOf(this ITypeSymbol symbol, ITypeSymbol type)
         {
-            return symbol.DirectlyImplements(type) || Equals(symbol.BaseType, type);
+            return symbol.DirectlyImplements(type) || type.EqualsDisregardingNullability(symbol.BaseType);
         }
 
         public static bool DirectlyImplements(this ITypeSymbol symbol, ITypeSymbol type)
@@ -41,7 +42,7 @@ namespace ExhaustiveMatching.Analyzer.Semantics
 
         public static bool InheritsFrom(this ITypeSymbol symbol, ITypeSymbol type)
         {
-            return symbol.BaseClasses().Any(t => t.Equals(type));
+            return symbol.BaseClasses().Any(t => t.EqualsDisregardingNullability(type));
         }
 
         public static bool IsDirectSubtypeOfTypeWithAttribute(
@@ -54,7 +55,7 @@ namespace ExhaustiveMatching.Analyzer.Semantics
 
         public static bool HasAttribute(this ITypeSymbol symbol, INamedTypeSymbol attributeType)
         {
-            return symbol.GetAttributes().Any(a => a.AttributeClass != null && SymbolEqualityComparer.Default.Equals(a.AttributeClass, attributeType));
+            return symbol.GetAttributes().Any(a => attributeType.EqualsDisregardingNullability(a.AttributeClass));
         }
 
         public static IEnumerable<TypeSyntax> GetCaseTypeSyntaxes(
@@ -63,7 +64,7 @@ namespace ExhaustiveMatching.Analyzer.Semantics
         {
             return type.GetAttributes()
                        .Where(attr => attr.AttributeClass != null && attr.ApplicationSyntaxReference != null)
-                       .Where(attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, closedAttributeType))
+                       .Where(attr => closedAttributeType.EqualsDisregardingNullability(attr.AttributeClass))
                        .Select(attr => attr.ApplicationSyntaxReference!.GetSyntax()).Cast<AttributeSyntax>()
                        .SelectMany(attr => attr.ArgumentList?.Arguments ?? default)
                        .Select(arg => arg.Expression)
@@ -79,7 +80,7 @@ namespace ExhaustiveMatching.Analyzer.Semantics
             INamedTypeSymbol closedAttributeType)
         {
             return type.GetAttributes()
-                       .Where(a => a.AttributeClass != null && SymbolEqualityComparer.Default.Equals(a.AttributeClass, closedAttributeType))
+                       .Where(a => closedAttributeType.EqualsDisregardingNullability(a.AttributeClass))
                        .SelectMany(a => a.ConstructorArguments)
                        .SelectMany(GetTypeConstants)
                        .Select(arg => arg.Value)
@@ -191,7 +192,7 @@ namespace ExhaustiveMatching.Analyzer.Semantics
                         || (rootType.IsRecord
                             && c.DeclaredAccessibility == Accessibility.Protected
                             && c.Parameters.Length == 1
-                            && SymbolEqualityComparer.Default.Equals(c.Parameters[0].Type, rootType))
+                            && rootType.EqualsDisregardingNullability(c.Parameters[0].Type))
                     ))
             {
 

--- a/ExhaustiveMatching.Analyzer/Syntax/ExpressionSyntaxExtensions.cs
+++ b/ExhaustiveMatching.Analyzer/Syntax/ExpressionSyntaxExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using ExhaustiveMatching.Analyzer.Enums.Semantics;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -7,7 +8,7 @@ namespace ExhaustiveMatching.Analyzer.Syntax
 {
     public static class ExpressionSyntaxExtensions
     {
-        public static bool IsTypeIdentifier(this ExpressionSyntax expression, SyntaxNodeAnalysisContext context, out ITypeSymbol typeSymbol)
+        public static bool IsTypeIdentifier(this ExpressionSyntax expression, SyntaxNodeAnalysisContext context, [NotNullWhen(true)] out ITypeSymbol? typeSymbol)
         {
             if (context.GetSymbol(expression) is ITypeSymbol t)
             {

--- a/ExhaustiveMatching.Analyzer/SyntaxNodeAnalysisContextExtensions.cs
+++ b/ExhaustiveMatching.Analyzer/SyntaxNodeAnalysisContextExtensions.cs
@@ -25,9 +25,7 @@ namespace ExhaustiveMatching.Analyzer
         #endregion
 
         #region Report Switch Diagnostics
-        public static void ReportCasePatternNotSupported(
-            this SyntaxNodeAnalysisContext context,
-            CaseSwitchLabelSyntax switchLabel)
+        public static void ReportCasePatternNotSupported(this SyntaxNodeAnalysisContext context, CaseSwitchLabelSyntax switchLabel)
         {
             var diagnostic = Diagnostic.Create(
                 Diagnostics.CasePatternNotSupported,
@@ -43,10 +41,7 @@ namespace ExhaustiveMatching.Analyzer
             context.ReportDiagnostic(diagnostic);
         }
 
-        public static void ReportOpenTypeNotSupported(
-            this SyntaxNodeAnalysisContext context,
-            ITypeSymbol type,
-            ExpressionSyntax switchStatementExpression)
+        public static void ReportOpenTypeNotSupported(this SyntaxNodeAnalysisContext context, ITypeSymbol type, ExpressionSyntax switchStatementExpression)
         {
             var diagnostic = Diagnostic.Create(
                 Diagnostics.OpenTypeNotSupported,
@@ -54,9 +49,7 @@ namespace ExhaustiveMatching.Analyzer
             context.ReportDiagnostic(diagnostic);
         }
 
-        public static void ReportWhenClauseNotSupported(
-            this SyntaxNodeAnalysisContext context,
-            WhenClauseSyntax whenClause)
+        public static void ReportWhenClauseNotSupported(this SyntaxNodeAnalysisContext context, WhenClauseSyntax whenClause)
         {
             var diagnostic = Diagnostic.Create(
                                 Diagnostics.WhenGuardNotSupported,
@@ -65,12 +58,10 @@ namespace ExhaustiveMatching.Analyzer
         }
         #endregion
 
-        public static INamedTypeSymbol GetClosedAttributeType(this SyntaxNodeAnalysisContext context)
+        public static INamedTypeSymbol? GetClosedAttributeType(this SyntaxNodeAnalysisContext context)
             => context.Compilation.GetTypeByMetadataName(TypeNames.ClosedAttribute);
 
-        public static ITypeSymbol GetDeclarationType(
-            this SyntaxNodeAnalysisContext context,
-            DeclarationPatternSyntax declarationPattern)
+        public static ITypeSymbol? GetDeclarationType(this SyntaxNodeAnalysisContext context, DeclarationPatternSyntax declarationPattern)
             => context.SemanticModel.GetTypeInfo(declarationPattern.Type, context.CancellationToken).Type;
     }
 }

--- a/ExhaustiveMatching.Analyzer/Utility/NullableAttributes.cs
+++ b/ExhaustiveMatching.Analyzer/Utility/NullableAttributes.cs
@@ -1,0 +1,209 @@
+﻿// https://www.meziantou.net/how-to-use-nullable-reference-types-in-dotnet-standard-2-0-and-dotnet-.htm
+// https://github.com/dotnet/runtime/blob/527f9ae88a0ee216b44d556f9bdc84037fe0ebda/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
+
+#pragma warning disable
+#define INTERNAL_NULLABLE_ATTRIBUTES
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+#if NETSTANDARD2_0 ||  NETCOREAPP2_0 ||  NETCOREAPP2_1 ||  NETCOREAPP2_2 || NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
+    /// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class AllowNullAttribute : Attribute
+    { }
+
+    /// <summary>Specifies that null is disallowed as an input even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class DisallowNullAttribute : Attribute
+    { }
+
+    /// <summary>Specifies that an output may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class MaybeNullAttribute : Attribute
+    { }
+
+    /// <summary>Specifies that an output will not be null even if the corresponding type allows it. Specifies that an input argument was not null when the call returns.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class NotNullAttribute : Attribute
+    { }
+
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class MaybeNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter may be null.
+        /// </param>
+        public MaybeNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class NotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+    /// <summary>Specifies that the output will be non-null if the named parameter is non-null.</summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class NotNullIfNotNullAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the associated parameter name.</summary>
+        /// <param name="parameterName">
+        /// The associated parameter name.  The output will be non-null if the argument to the parameter specified is non-null.
+        /// </param>
+        public NotNullIfNotNullAttribute(string parameterName) => ParameterName = parameterName;
+
+        /// <summary>Gets the associated parameter name.</summary>
+        public string ParameterName { get; }
+    }
+
+    /// <summary>Applied to a method that will never return under any circumstance.</summary>
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class DoesNotReturnAttribute : Attribute
+    { }
+
+    /// <summary>Specifies that the method will not return if the associated Boolean parameter is passed the specified value.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class DoesNotReturnIfAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified parameter value.</summary>
+        /// <param name="parameterValue">
+        /// The condition parameter value. Code after the method will be considered unreachable by diagnostics if the argument to
+        /// the associated parameter matches this value.
+        /// </param>
+        public DoesNotReturnIfAttribute(bool parameterValue) => ParameterValue = parameterValue;
+
+        /// <summary>Gets the condition parameter value.</summary>
+        public bool ParameterValue { get; }
+    }
+#endif
+
+#if NETSTANDARD2_0 ||  NETCOREAPP2_0 ||  NETCOREAPP2_1 ||  NETCOREAPP2_2 || NETCOREAPP3_0 || NETCOREAPP3_1 || NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
+    /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values.</summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class MemberNotNullAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with a field or property member.</summary>
+        /// <param name="member">
+        /// The field or property member that is promised to be not-null.
+        /// </param>
+        public MemberNotNullAttribute(string member) => Members = new[] { member };
+
+        /// <summary>Initializes the attribute with the list of field and property members.</summary>
+        /// <param name="members">
+        /// The list of field and property members that are promised to be not-null.
+        /// </param>
+        public MemberNotNullAttribute(params string[] members) => Members = members;
+
+        /// <summary>Gets field or property member names.</summary>
+        public string[] Members { get; }
+    }
+
+    /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values when returning with the specified return value condition.</summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class MemberNotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition and a field or property member.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        /// <param name="member">
+        /// The field or property member that is promised to be not-null.
+        /// </param>
+        public MemberNotNullWhenAttribute(bool returnValue, string member)
+        {
+            ReturnValue = returnValue;
+            Members = new[] { member };
+        }
+
+        /// <summary>Initializes the attribute with the specified return value condition and list of field and property members.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        /// <param name="members">
+        /// The list of field and property members that are promised to be not-null.
+        /// </param>
+        public MemberNotNullWhenAttribute(bool returnValue, params string[] members)
+        {
+            ReturnValue = returnValue;
+            Members = members;
+        }
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+
+        /// <summary>Gets field or property member names.</summary>
+        public string[] Members { get; }
+    }
+#endif
+}

--- a/ExhaustiveMatching.Examples/.editorconfig
+++ b/ExhaustiveMatching.Examples/.editorconfig
@@ -5,5 +5,11 @@
 # EM0001: Switch on Enum Not Exhaustive
 dotnet_diagnostic.EM0001.severity = suggestion
 
-# EM0002: Switch on Closed Type Not Exhaustive
+# EM0002: Switch on Nullable Enum Type Not Exhaustive
 dotnet_diagnostic.EM0002.severity = suggestion
+
+# EM0003: Switch on Closed Type Not Exhaustive
+dotnet_diagnostic.EM0003.severity = suggestion
+
+# EM0101: Case Pattern Not Supported
+#dotnet_diagnostic.EM0101.severity = suggestion

--- a/ExhaustiveMatching.Examples/ReadMe/CoinFlipExample.cs
+++ b/ExhaustiveMatching.Examples/ReadMe/CoinFlipExample.cs
@@ -17,6 +17,7 @@ namespace Examples.ReadMe
         public static void Example(CoinFlip coinFlip)
         {
             #region snippet
+            // EM0001: Switch on Enum Not Exhaustive
             // ERROR Enum value not handled by switch: Tails
             switch (coinFlip)
             {
@@ -27,11 +28,12 @@ namespace Examples.ReadMe
                     break;
             }
 
+            // EM0001: Switch on Enum Not Exhaustive
             // ERROR Enum value not handled by switch: Tails
             _ = coinFlip switch
             {
                 CoinFlip.Heads => "Heads!",
-                _ => throw ExhaustiveMatch.Failed(coinFlip),
+                    _ => throw ExhaustiveMatch.Failed(coinFlip),
             };
             #endregion
         }

--- a/ExhaustiveMatching.Examples/ReadMe/DayOfWeekExample.cs
+++ b/ExhaustiveMatching.Examples/ReadMe/DayOfWeekExample.cs
@@ -10,6 +10,7 @@ namespace Examples.ReadMe
         public static void Example(DayOfWeek dayOfWeek)
         {
             #region snippet
+            // EM0001: Switch on Enum Not Exhaustive
             // ERROR Enum value not handled by switch: Sunday
             switch (dayOfWeek)
             {

--- a/ExhaustiveMatching.Examples/ReadMe/IPAddressExample.cs
+++ b/ExhaustiveMatching.Examples/ReadMe/IPAddressExample.cs
@@ -19,6 +19,7 @@ namespace Examples.ReadMe
         public static IPv6Address Example(IPAddress ipAddress)
         {
             #region snippet
+            // EM0003: Switch on Closed Type Not Exhaustive
             // ERROR Subtype not handled by switch: IPv6Address
             switch (ipAddress)
             {


### PR DESCRIPTION
In preparation for another (unrelated) PR I'd like to submit shortly, I've added C# 8.0 nullable annotations to the analyzer's source and fixed other current code analysis warnings listed in VS2022.